### PR TITLE
Improve frontend typography and styling

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <title>AD File Share</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,56 @@
+body {
+  font-family: 'Roboto', sans-serif;
+  background-color: #f0f2f5;
+  color: #333;
+}
+
+.container {
+  max-width: 400px;
+  margin: 50px auto;
+  padding: 30px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.text-input {
+  width: 100%;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.btn {
+  display: inline-block;
+  padding: 8px 16px;
+  background-color: #2062c5;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn:hover {
+  background-color: #1b4f9e;
+}
+
+.file-section {
+  margin-top: 24px;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.file-link {
+  cursor: pointer;
+  color: #2062c5;
+}
+
+a {
+  color: #2062c5;
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import './App.css';
 
 const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
@@ -128,41 +129,52 @@ function App() {
 
   if (!loggedIn) {
     return (
-      <div style={{ maxWidth: 300, margin: "50px auto", padding: 30, border: "1px solid #ccc", borderRadius: 8 }}>
+      <div className="container">
         <h2>AD Girişi</h2>
         <form onSubmit={handleLogin}>
-          <input placeholder="Kullanıcı adı" value={username} onChange={e => setUsername(e.target.value)} style={{ width: "100%", marginBottom: 8 }} /><br />
-          <input placeholder="Şifre" type="password" value={password} onChange={e => setPassword(e.target.value)} style={{ width: "100%", marginBottom: 12 }} /><br />
-          <button type="submit" style={{ width: "100%" }}>Giriş</button>
+          <input
+            placeholder="Kullanıcı adı"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            className="text-input"
+          /><br />
+          <input
+            placeholder="Şifre"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            className="text-input"
+          /><br />
+          <button type="submit" className="btn">Giriş</button>
         </form>
       </div>
     );
   }
 
   return (
-    <div style={{ maxWidth: 400, margin: "50px auto", padding: 30, border: "1px solid #ccc", borderRadius: 8 }}>
+    <div className="container">
       <h2>Dosya Yükle</h2>
       <form onSubmit={handleUpload}>
         <input type="file" onChange={e => setSelectedFile(e.target.files[0])} /><br /><br />
-        <button type="submit">Yükle</button>
+        <button type="submit" className="btn">Yükle</button>
       </form>
-      <div style={{ marginTop: 24 }}>
+      <div className="file-section">
         <h3>Yüklediğiniz Dosyalar:</h3>
         <ul>
           {userFiles.map(file => (
-            <li key={file} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <span style={{ cursor: 'pointer', color: '#2062c5' }} onClick={() => handleDownload(file)}>{file}</span>
-              <button style={{ marginLeft: 10 }} onClick={() => handleDelete(file)}>Sil</button>
+            <li key={file} className="file-item">
+              <span className="file-link" onClick={() => handleDownload(file)}>{file}</span>
+              <button onClick={() => handleDelete(file)}>Sil</button>
               <button onClick={() => handleShare(file)}>Paylaş</button>
               {sharedLinks[file] && (
-                <a href={sharedLinks[file]} target="_blank" rel="noopener noreferrer" style={{ marginLeft: 8 }}>
+                <a href={sharedLinks[file]} target="_blank" rel="noopener noreferrer">
                   Link
                 </a>
               )}
             </li>
           ))}
         </ul>
-        <button onClick={() => setLoggedIn(false)}>Çıkış</button>
+        <button className="btn" onClick={() => setLoggedIn(false)}>Çıkış</button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add Roboto font and global CSS to enhance layout and typography
- Replace inline styles with CSS classes for cleaner file list styling

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891f7a086f4832b92dc2905560cf251