### PR TITLE
feat: support chunked uploads with progress

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -84,20 +84,60 @@ dropZone.addEventListener('drop', (e) => {
 fileInput.addEventListener('change', () => handleFiles(fileInput.files));
 
 async function handleFiles(files) {
-    const formData = new FormData();
-    for (const file of files) {
-        formData.append('files', file);
-    }
-    formData.append('username', username);
-    const res = await fetch('/upload', { method: 'POST', body: formData });
-    const json = await res.json();
     const result = document.getElementById('upload-result');
-    if (json.success) {
-        result.innerHTML = '<div class="alert alert-success">' + json.filenames.join(', ') + ' yüklendi</div>';
-        loadFiles();
-    } else {
-        result.innerHTML = '<div class="alert alert-danger">' + (json.error || 'Hata') + '</div>';
+    result.innerHTML = '';
+    for (const file of files) {
+        try {
+            await uploadFile(file);
+        } catch (e) {
+            result.innerHTML = '<div class="alert alert-danger">' + (e.message || 'Hata') + '</div>';
+            return;
+        }
     }
+    result.innerHTML += '<div class="alert alert-success">Dosyalar yüklendi</div>';
+    loadFiles();
+}
+
+async function uploadFile(file) {
+    const chunkSize = 5 * 1024 * 1024; // 5MB
+    const totalChunks = Math.ceil(file.size / chunkSize);
+    const bar = createProgressBar(file.name);
+
+    for (let i = 0; i < totalChunks; i++) {
+        const start = i * chunkSize;
+        const end = Math.min(file.size, start + chunkSize);
+        const chunk = file.slice(start, end);
+        const formData = new FormData();
+        formData.append('username', username);
+        formData.append('filename', file.name);
+        formData.append('chunk_index', i);
+        formData.append('total_chunks', totalChunks);
+        formData.append('file', chunk);
+        const res = await fetch('/upload', { method: 'POST', body: formData });
+        const json = await res.json();
+        if (!json.success) {
+            throw new Error(json.error || 'Yükleme başarısız');
+        }
+        bar.style.width = ((i + 1) / totalChunks * 100) + '%';
+    }
+    bar.classList.add('bg-success');
+}
+
+function createProgressBar(filename) {
+    const container = document.createElement('div');
+    container.className = 'mb-2';
+    const label = document.createElement('div');
+    label.textContent = filename;
+    const progress = document.createElement('div');
+    progress.className = 'progress';
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar';
+    bar.style.width = '0%';
+    progress.appendChild(bar);
+    container.appendChild(label);
+    container.appendChild(progress);
+    document.getElementById('upload-result').appendChild(container);
+    return bar;
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- handle uploads in chunks to bypass 100MB limits
- show per-file progress bars during upload

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689220a23e64832ba7e9bacaca02c035