### PR TITLE
Allow configuring LDAP search filter via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ docker-compose up --build
 ```
 
 The application will be available at `http://localhost:8080/`.
+
+## Configuration
+
+The backend reads LDAP settings from environment variables. To customize how user
+names are searched, set `LDAP_SEARCH_FILTER` in the environment. The string
+should contain a `{query}` placeholder that will be replaced with the incoming
+search text. By default the application uses
+`(&(objectClass=user)(sAMAccountName=*{query}*))`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,9 @@ LDAP_DOMAIN = os.getenv("LDAP_DOMAIN")
 LDAP_USER = os.getenv("LDAP_USER")
 LDAP_PASSWORD = os.getenv("LDAP_PASSWORD")
 LDAP_BASE_DN = os.getenv("LDAP_BASE_DN", "")
+LDAP_SEARCH_FILTER = os.getenv(
+    "LDAP_SEARCH_FILTER", "(&(objectClass=user)(sAMAccountName=*{query}*))"
+)
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
@@ -145,7 +148,7 @@ def list_users():
         )
         if not conn.bind():
             return jsonify(success=False, error="LDAP bağlantısı başarısız")
-        search_filter = f"(&(objectClass=user)(sAMAccountName=*{query}*))"
+        search_filter = LDAP_SEARCH_FILTER.format(query=query)
         conn.search(LDAP_BASE_DN, search_filter, attributes=["sAMAccountName"])
         users = [e.sAMAccountName.value for e in conn.entries]
         return jsonify(users=users)


### PR DESCRIPTION
## Summary
- allow overriding LDAP user search filter through `LDAP_SEARCH_FILTER`
- document configurable search filter environment variable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689254e83238832ba2371d6303783698