### PR TITLE
Fix team deletion to remove associated files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -347,6 +347,7 @@ def delete_team():
         if team.creator != username:
             return jsonify(success=False, error="Yetkiniz yok")
         db.query(TeamMember).filter_by(team_id=team_id).delete()
+        db.query(TeamFile).filter_by(team_id=team_id).delete()
         db.delete(team)
         db.commit()
         return jsonify(success=True)


### PR DESCRIPTION
## Summary
- Remove team files before deleting a team to avoid foreign key errors

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892583c04fc832b98354d69d0b69dad