### PR TITLE
Add icons to navigation menu

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>File Share</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 </head>
 <body>
 <div class="d-flex">
@@ -11,10 +12,10 @@
         <div class="p-3">
             <h5>Menü</h5>
             <ul class="nav flex-column">
-                <li class="nav-item"><a class="nav-link" href="#upload">Yükle</a></li>
-                <li class="nav-item"><a class="nav-link" href="#files">Dosyalarım</a></li>
+                <li class="nav-item"><a class="nav-link" href="#upload"><i class="bi bi-upload me-2"></i>Yükle</a></li>
+                <li class="nav-item"><a class="nav-link" href="#files"><i class="bi bi-folder2-open me-2"></i>Dosyalarım</a></li>
                 <li class="nav-item">
-                    <a class="nav-link" href="#teams">Ekipler</a>
+                    <a class="nav-link" href="#teams"><i class="bi bi-people me-2"></i>Ekipler</a>
                     <ul id="team-menu" class="nav flex-column ms-3"></ul>
                 </li>
             </ul>
@@ -260,7 +261,7 @@ async function loadTeams() {
         const link = document.createElement('a');
         link.className = 'nav-link';
         link.href = '#teams';
-        link.textContent = team.name;
+        link.innerHTML = '<i class="bi bi-people me-2"></i>' + team.name;
         menuItem.appendChild(link);
         menu.appendChild(menuItem);
 


### PR DESCRIPTION
## Summary
- add Bootstrap Icons library for menu visuals
- display upload, file, and team icons in sidebar links
- show a people icon for dynamically loaded team entries

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892eddc85fc832b9085f96959d742dd