### PR TITLE
Fix team list items not opening details

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -419,20 +419,24 @@ async function loadTeams() {
 
         const li = document.createElement('li');
         li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.style.cursor = 'pointer';
+        li.addEventListener('click', () => viewTeam(team.id));
+
         const nameSpan = document.createElement('span');
-        nameSpan.style.cursor = 'pointer';
         nameSpan.textContent = team.name;
-        nameSpan.addEventListener('click', () => viewTeam(team.id));
         li.appendChild(nameSpan);
+
         const membersSpan = document.createElement('span');
         membersSpan.className = 'ms-2';
         membersSpan.textContent = `(${team.members.map(m => m.name).join(', ')})`;
         li.appendChild(membersSpan);
+
         const btn = document.createElement('button');
         const isCreator = team.creator === username;
         btn.className = 'btn btn-sm ' + (isCreator ? 'btn-danger' : 'btn-outline-secondary');
         btn.textContent = isCreator ? 'Sil' : 'Ayrıl';
-        btn.addEventListener('click', async () => {
+        btn.addEventListener('click', async (e) => {
+            e.stopPropagation();
             const data = new FormData();
             data.append('username', username);
             data.append('team_id', team.id);
@@ -440,6 +444,7 @@ async function loadTeams() {
             loadTeams();
         });
         li.appendChild(btn);
+
         list.appendChild(li);
     });
 }


### PR DESCRIPTION
## Summary
- Make entire team list item clickable so team details open reliably
- Stop propagation on team action buttons to prevent accidental detail view

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892fe60b430832ba2f76a139143758d