### PR TITLE
Replace share modal with inline link copy

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -156,23 +156,6 @@
   </div>
 </div>
 
-<div class="modal fade" id="linkModal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Paylaşım Linki</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <input type="text" id="share-link-input" class="form-control" readonly>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="copy-link">Copy</button>
-      </div>
-    </div>
-  </div>
-</div>
-
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 const username = localStorage.getItem('username');
@@ -193,8 +176,6 @@ const deleteBtn = document.getElementById('delete-selected');
 const shareBtn = document.getElementById('share-selected');
 const addToTeamBtn = document.getElementById('add-to-team');
 const publicShareBtn = document.getElementById('public-share');
-const linkInput = document.getElementById('share-link-input');
-const copyLinkBtn = document.getElementById('copy-link');
 let teams = [];
 let currentTeamId = null;
 let userModalMode = 'create';
@@ -286,10 +267,14 @@ async function loadFiles() {
             const linkBtn = document.createElement('button');
             linkBtn.className = 'btn btn-sm btn-outline-primary ms-2';
             linkBtn.textContent = 'Link';
-            linkBtn.addEventListener('click', () => {
-                linkInput.value = window.location.origin + file.link;
-                const modal = new bootstrap.Modal(document.getElementById('linkModal'));
-                modal.show();
+            linkBtn.addEventListener('click', async () => {
+                const url = window.location.origin + file.link;
+                await navigator.clipboard.writeText(url);
+                const msg = document.createElement('span');
+                msg.className = 'ms-2 text-success';
+                msg.textContent = 'URL kopyalandı';
+                linkBtn.insertAdjacentElement('afterend', msg);
+                setTimeout(() => msg.remove(), 2000);
             });
             titleTd.appendChild(linkBtn);
         }
@@ -396,9 +381,6 @@ publicShareBtn.addEventListener('click', async () => {
     const res = await fetch('/share', { method: 'POST', body: formData });
     const json = await res.json();
     if (json.success) {
-        linkInput.value = window.location.origin + json.link;
-        const modal = new bootstrap.Modal(document.getElementById('linkModal'));
-        modal.show();
         await loadFiles();
     }
 });
@@ -415,10 +397,6 @@ addToTeamBtn.addEventListener('click', () => {
     });
     const modal = new bootstrap.Modal(document.getElementById('teamModal'));
     modal.show();
-});
-
-copyLinkBtn.addEventListener('click', () => {
-    navigator.clipboard.writeText(linkInput.value);
 });
 
 shareBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- remove unused share link modal
- show link buttons that copy URLs to clipboard with a temporary success message
- refresh file list after sharing without triggering a popup

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6893216067ac832b8d3a65909db3a312