### PR TITLE
Add landing page for public file downloads

### DIFF
--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <title>Paylaşılan Dosya</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .logo {
+            max-width: 200px;
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+<div class="text-center">
+    <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo" class="logo">
+    {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+    {% else %}
+        <h2>{{ filename }}</h2>
+        <p>Paylaşan: {{ uploader }}</p>
+        <p>Boyut: {{ size_kb }} KB</p>
+        <a class="btn btn-primary" href="{{ url_for('public_download_file', token=token) }}">Download</a>
+    {% endif %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce landing page for public share links showing file info and download button
- handle missing or expired public links with an informative message
- add static directory for future logo placement

## Testing
- `pytest`
- `python -m py_compile backend/main.py`
- `flake8 backend/main.py` *(fails: command not found; attempted `pip install flake8` but proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68933069b17c832ba1bc4a39c37f2643