### PR TITLE
Make sidebar static and add logo

### DIFF
--- a/backend/static/logo.svg
+++ b/backend/static/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#0d6efd"/>
+  <text x="32" y="37" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" fill="white">FS</text>
+</svg>

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -8,8 +8,9 @@
 </head>
 <body>
 <div class="d-flex">
-    <nav id="sidebar" class="collapse collapse-horizontal show bg-light border-end" style="--bs-collapse-width: 250px;">
+    <nav id="sidebar" class="bg-light border-end vh-100 flex-shrink-0" style="width: 250px;">
         <div class="p-3">
+            <img src="{{ url_for('static', filename='logo.svg') }}" alt="Logo" class="img-fluid mb-3" style="max-width: 80px;">
             <h5>Menü</h5>
             <ul class="nav flex-column">
                 <li class="nav-item"><a class="nav-link" href="#upload"><i class="bi bi-upload me-2"></i>Yükle</a></li>
@@ -29,9 +30,6 @@
     </nav>
 
     <div class="flex-grow-1 p-3">
-        <button class="btn btn-outline-secondary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar" aria-controls="sidebar">
-            &#9776;
-        </button>
         <div class="d-flex align-items-center mb-3">
             <h1 class="me-3 mb-0">Hoş geldin, <span id="username-display"></span></h1>
             <button id="logout-btn" class="btn btn-outline-secondary btn-sm">Çıkış</button>


### PR DESCRIPTION
## Summary
- add small logo to sidebar navigation
- make sidebar fixed by removing collapse behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893382ffab0832bb4209ebbd0b1841b