### PR TITLE
Use PNG logo and remove sidebar menu heading

### DIFF
--- a/backend/static/logo.svg
+++ b/backend/static/logo.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="8" ry="8" fill="#0d6efd"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" fill="white">FS</text>
-</svg>

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -10,8 +10,7 @@
 <div class="d-flex">
     <nav id="sidebar" class="bg-light border-end vh-100 flex-shrink-0" style="width: 250px;">
         <div class="p-3">
-            <img src="{{ url_for('static', filename='logo.svg') }}" alt="Logo" class="img-fluid mb-3" style="max-width: 80px;">
-            <h5>Menü</h5>
+            <img src="{{ url_for('static', filename='logo-small.png') }}" alt="Logo" class="img-fluid mb-3" style="max-width: 80px;">
             <ul class="nav flex-column">
                 <li class="nav-item"><a class="nav-link" href="#upload"><i class="bi bi-upload me-2"></i>Yükle</a></li>
                 <li class="nav-item">


### PR DESCRIPTION
## Summary
- replace sidebar SVG logo with link to `logo-small.png`
- keep large logo on public download page via `logo.png`
- remove "Menü" heading from sidebar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933a7197f4832b8066bad8f058adc4