### PR TITLE
Require manager approval for public links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ names are searched, set `LDAP_SEARCH_FILTER` in the environment. The string
 should contain a `{query}` placeholder that will be replaced with the incoming
 search text. By default the application uses
 `(&(objectClass=user)(sAMAccountName=*{query}*))`.
+
+For public shares requiring manager approval, the backend sends an e-mail to the
+user's manager. Configure SMTP settings with the following variables:
+
+- `SMTP_SERVER` and `SMTP_PORT`
+- `SMTP_USER` and `SMTP_PASSWORD` if authentication is needed
+- `SMTP_FROM` for the sender address (defaults to `no-reply@example.com`)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -161,6 +161,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
+        <div class="alert alert-info">Bölüm amirinin onayı sonrası dosya paylaşıma açılacaktır.</div>
         <select id="share-expiry" class="form-select">
           <option value="1">1 gün</option>
           <option value="7" selected>7 gün</option>
@@ -318,6 +319,12 @@ async function loadFiles() {
                 setTimeout(() => msg.remove(), 2000);
             });
             titleTd.appendChild(linkBtn);
+
+            const statusBtn = document.createElement('button');
+            statusBtn.className = 'btn btn-sm ms-2 ' + (file.approved ? 'btn-success' : 'btn-warning');
+            statusBtn.textContent = file.approved ? 'Onaylandı' : 'Onay bekliyor';
+            statusBtn.disabled = true;
+            titleTd.appendChild(statusBtn);
         }
         tr.appendChild(titleTd);
 
@@ -343,6 +350,10 @@ async function loadFiles() {
 
         tbody.appendChild(tr);
     });
+
+    if (json.files.some(f => f.link && !f.approved)) {
+        setTimeout(loadFiles, 5000);
+    }
 }
 
 async function loadIncoming() {


### PR DESCRIPTION
## Summary
- Require manager approval for public share links and email managers with approval links
- Block public links until approved and expose an approval endpoint
- Display approval status and guidance in the UI, polling for updates

## Testing
- `pytest`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689342c34110832baead262d271240ba