### PR TITLE
Add pending approvals section and use Graph API for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ search text. By default the application uses
 `(&(objectClass=user)(sAMAccountName=*{query}*))`.
 
 For public shares requiring manager approval, the backend sends an e-mail to the
-user's manager. Configure SMTP settings with the following variables:
+user's manager through the Microsoft Graph API. Configure the following variables:
 
-- `SMTP_SERVER` and `SMTP_PORT`
-- `SMTP_USER` and `SMTP_PASSWORD` if authentication is needed
-- `SMTP_FROM` for the sender address (defaults to `no-reply@example.com`)
+- `GRAPH_TENANT_ID`
+- `GRAPH_CLIENT_ID`
+- `GRAPH_CLIENT_SECRET`
+- `GRAPH_SENDER` for the account used to send mail

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,6 @@ python-dotenv
 passlib
 pycryptodome
 jinja2
+msal
+requests
 

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -18,6 +18,7 @@
                     <ul class="nav flex-column ms-3">
                         <li class="nav-item"><a class="nav-link" href="#incoming"><i class="bi bi-inbox me-2"></i>Gelen Dosyalar</a></li>
                         <li class="nav-item"><a class="nav-link" href="#outgoing"><i class="bi bi-box-arrow-up me-2"></i>Giden Dosyalar</a></li>
+                        <li class="nav-item"><a class="nav-link" href="#pending"><i class="bi bi-hourglass-split me-2"></i>Onay Bekleyenler</a></li>
                     </ul>
                 </li>
                 <li class="nav-item">
@@ -88,6 +89,20 @@
                         <th>Dosya</th>
                         <th>Alıcı</th>
                         <th>Geçerlilik</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+
+        <section id="pending" class="d-none">
+            <h2>Onay Bekleyenler</h2>
+            <table id="pending-table" class="table">
+                <thead>
+                    <tr>
+                        <th>Dosya</th>
+                        <th>Gönderen</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -211,6 +226,7 @@ const sections = {
     files: document.getElementById('files'),
     incoming: document.getElementById('incoming'),
     outgoing: document.getElementById('outgoing'),
+    pending: document.getElementById('pending'),
     teams: document.getElementById('teams'),
     'team-details': document.getElementById('team-details')
 };
@@ -231,6 +247,8 @@ function showSection(id) {
             loadIncoming();
         } else if (id === 'outgoing') {
             loadOutgoing();
+        } else if (id === 'pending') {
+            loadPending();
         }
     }
 }
@@ -408,6 +426,35 @@ async function loadOutgoing() {
             data.append('type', file.type);
             await fetch('/outgoing/delete', { method: 'POST', body: data });
             loadOutgoing();
+        });
+        actTd.appendChild(btn);
+        tr.appendChild(actTd);
+        tbody.appendChild(tr);
+    });
+}
+
+async function loadPending() {
+    const fd = new FormData();
+    fd.append('username', username);
+    const res = await fetch('/share/pending', { method: 'POST', body: fd });
+    const json = await res.json();
+    const tbody = document.querySelector('#pending-table tbody');
+    tbody.innerHTML = '';
+    json.shares.forEach(item => {
+        const tr = document.createElement('tr');
+        const fileTd = document.createElement('td');
+        fileTd.textContent = item.filename;
+        tr.appendChild(fileTd);
+        const userTd = document.createElement('td');
+        userTd.textContent = item.username;
+        tr.appendChild(userTd);
+        const actTd = document.createElement('td');
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-sm btn-success';
+        btn.textContent = 'Onayla';
+        btn.addEventListener('click', async () => {
+            await fetch(`/share/approve/${item.token}`);
+            loadPending();
         });
         actTd.appendChild(btn);
         tr.appendChild(actTd);


### PR DESCRIPTION
## Summary
- Allow department managers to see and approve pending file shares
- Send approval emails through Microsoft Graph API instead of SMTP
- Document Microsoft Graph configuration and add required dependencies

## Testing
- `python -m py_compile backend/main.py`
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689345c413b4832bad2c5b1c74639c2e