### PR TITLE
Ensure share link table includes rejected flag

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -140,6 +140,13 @@ def add_missing_columns():
                     "ALTER TABLE share_links ADD COLUMN approved BOOLEAN DEFAULT FALSE"
                 )
             )
+    if "rejected" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE share_links ADD COLUMN rejected BOOLEAN DEFAULT FALSE"
+                )
+            )
 
 
 add_missing_columns()


### PR DESCRIPTION
## Summary
- add migration to create `rejected` column for `share_links`

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934ddd7728832b9d339808140f46a4