### PR TITLE
Format approval email with full name

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -233,13 +233,22 @@ def get_manager_info(username: str):
 
 def send_approval_email(username: str, filename: str, token: str):
     _, manager_email = get_manager_info(username)
-    if not (manager_email and GRAPH_TENANT_ID and GRAPH_CLIENT_ID and GRAPH_CLIENT_SECRET and GRAPH_SENDER):
+    if not (
+        manager_email
+        and GRAPH_TENANT_ID
+        and GRAPH_CLIENT_ID
+        and GRAPH_CLIENT_SECRET
+        and GRAPH_SENDER
+    ):
         return
     approval_link = f"{request.host_url}share/approve/{token}"
     reject_link = f"{request.host_url}share/reject/{token}"
     subject = "Dosya Paylaşımı Onayı"
+    full_name = get_full_name(username)
     body = (
-        f"<p>{username} kullanıcısı '{filename}' dosyasını paylaşmak istiyor.</p>"
+        f"<p>Baylan Send Dosya Paylaşım Platformu</p>"
+        f"<p>'{full_name}' kullanıcısı '{filename}' dosyasını herkese açık olarak paylaşmak istiyor.</p>"
+        f"<p>Bu bağlantıya sahip olan 3. kişiler dosyayı indirebilir.</p>"
         f"<p>"
         f"<a href='{approval_link}' style='padding:10px 20px; background-color:#4CAF50; color:white; text-decoration:none;'>Onayla</a>"
         f"<a href='{reject_link}' style='padding:10px 20px; background-color:#f44336; color:white; text-decoration:none; margin-left:10px;'>Reddet</a>"


### PR DESCRIPTION
## Summary
- Add full name to approval emails instead of username
- Expand approval email body to include platform name and public share warning

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893536100bc832bb5bd271e07d488e2