### PR TITLE
Adjust login page heading and logo size

### DIFF
--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -11,9 +11,9 @@
         <div class="col-md-4">
             <div class="card">
                 <div class="card-body">
-                    <img src="{{ url_for('static', filename='logo.png') }}" class="mx-auto d-block mb-3" alt="Logo">
-                    <h3 class="text-center">Baylan Dosya Paylaşım Platformu</h3>
-                    <p class="text-center mb-4">Hoş geldiniz</p>
+                    <img src="{{ url_for('static', filename='logo.png') }}" class="mx-auto d-block mb-3" alt="Logo" style="max-width: 200px;">
+                    <h4 class="text-center">Dosya Paylaşım Platformu</h4>
+                    <h3 class="text-center mb-4">Hoşgeldiniz</h3>
                     <form id="login-form">
                         <div class="mb-3">
                             <label class="form-label">Kullanıcı Adı</label>


### PR DESCRIPTION
## Summary
- limit login logo width to 200px
- update login page headings for platform and welcome text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893649d8fd8832b9ee1fb4b4cd38ced