### PR TITLE
Show unauthorized approval via template

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -282,7 +282,7 @@ def require_manager_auth(link):
         return redirect(f"/?next={request.path}")
     manager_user, _ = get_manager_info(link.username)
     if user != manager_user:
-        return Response("Yetkisiz", 403)
+        return render_template("message.html", message="Yetkisiz"), 403
     return None
 
 


### PR DESCRIPTION
## Summary
- render unauthorized approval through `message.html`

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689366136980832b8a03e9f36b87687f