### PR TITLE
Add warning icon for pending share approval message

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -177,7 +177,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <div class="alert alert-info">Bölüm amirinin onayı sonrası dosya paylaşıma açılacaktır.</div>
+        <div class="alert alert-info"><i class="bi bi-exclamation-triangle-fill me-2"></i>Bölüm amirinin onayı sonrası dosya paylaşıma açılacaktır.</div>
         <select id="share-expiry" class="form-select">
           <option value="1">1 gün</option>
           <option value="7" selected>7 gün</option>


### PR DESCRIPTION
## Summary
- add a triangular warning icon to share approval notice

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68936800a724832bb59fb5d3c845ec06