### PR TITLE
Serve app at root URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -279,7 +279,7 @@ def require_manager_auth(link):
     """Ensure the requester is the manager of the link's owner."""
     user = session.get("username")
     if not user:
-        return redirect(f"/?next={request.path}")
+        return redirect(f"/login?next={request.path}")
     manager_user, _ = get_manager_info(link.username)
     if user != manager_user:
         return render_template("message.html", message="Yetkisiz"), 403
@@ -411,13 +411,13 @@ def set_file_expiry(username: str, filename: str, expires_dt):
 
 
 @app.route("/", methods=["GET"])
-def read_index():
-    return render_template("login.html")
-
-
-@app.route("/app", methods=["GET"])
 def read_app():
     return render_template("app.html")
+
+
+@app.route("/login", methods=["GET"])
+def read_login():
+    return render_template("login.html")
 
 
 @app.route("/login", methods=["POST"])

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -197,7 +197,7 @@
 <script>
 const username = localStorage.getItem('username');
 if (!username) {
-    window.location.href = '/';
+    window.location.href = '/login';
 }
 
 const displayName = localStorage.getItem('name') || username;
@@ -205,7 +205,7 @@ document.getElementById('username-display').textContent = displayName;
 document.getElementById('logout-btn').addEventListener('click', () => {
     localStorage.removeItem('username');
     localStorage.removeItem('name');
-    window.location.href = '/';
+    window.location.href = '/login';
 });
 
 const selected = new Set();

--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -46,7 +46,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
         if (json.givenName) {
             localStorage.setItem('name', json.givenName);
         }
-        window.location.href = next || '/app';
+        window.location.href = next || '/';
     } else {
         document.getElementById('login-error').textContent = json.error || 'Giriş başarısız';
     }


### PR DESCRIPTION
## Summary
- Move main interface to hostname root instead of `/app`
- Add GET `/login` endpoint and update manager redirect logic
- Adjust client scripts to redirect through `/login` and root path

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936a0894cc832b8580a3fbc490f705