### PR TITLE
Add VirusTotal scanning and upload UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ should contain a `{query}` placeholder that will be replaced with the incoming
 search text. By default the application uses
 `(&(objectClass=user)(sAMAccountName=*{query}*))`.
 
+For optional VirusTotal scanning of uploaded files, provide `VT_API_KEY` in the
+environment. Files smaller than 50MB will be scanned before the upload button
+appears.
+
 For public shares requiring manager approval, the backend sends an e-mail to the
 user's manager through the Microsoft Graph API. Configure the following variables:
 

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -41,8 +41,10 @@
                 Dosyaları buraya sürükleyin veya tıklayın
                 <input type="file" id="file-input" name="files" multiple hidden>
             </div>
+            <h5 id="pending-title" class="d-none">Yüklenecek Dosyalar</h5>
             <ul id="file-list" class="list-group mb-2"></ul>
-            <div class="d-flex mb-2">
+            <div class="d-flex mb-2 align-items-center">
+                <label for="file-expiry" class="me-2">Geçerlilik Tarihi</label>
                 <select id="file-expiry" class="form-select me-2">
                     <option value="1">1 gün</option>
                     <option value="7">7 gün</option>
@@ -50,7 +52,7 @@
                     <option value="60">60 gün</option>
                     <option value="0">Süresiz</option>
                 </select>
-                <button id="upload-btn" class="btn btn-primary">Yükle</button>
+                <button id="upload-btn" class="btn btn-primary d-none">Yükle</button>
             </div>
             <div id="upload-result" class="mt-2"></div>
         </section>
@@ -873,19 +875,59 @@ dropZone.addEventListener('drop', (e) => {
     addFiles(e.dataTransfer.files);
 });
 fileInput.addEventListener('change', () => addFiles(fileInput.files));
-document.getElementById('upload-btn').addEventListener('click', handleUpload);
+const uploadBtn = document.getElementById('upload-btn');
+uploadBtn.addEventListener('click', handleUpload);
 
 const fileList = document.getElementById('file-list');
+const pendingTitle = document.getElementById('pending-title');
 let pendingFiles = [];
+const scanStatuses = new Map();
 
 function addFiles(files) {
+    uploadBtn.classList.add('d-none');
+    if (pendingFiles.length === 0) {
+        pendingTitle.classList.remove('d-none');
+    }
     for (const file of files) {
         pendingFiles.push(file);
         const li = document.createElement('li');
-        li.className = 'list-group-item';
-        li.textContent = file.name;
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.textContent = `${file.name} - ${formatSize(file.size)}`;
+        const status = document.createElement('span');
+        status.className = 'ms-2 text-muted';
+        li.appendChild(status);
         fileList.appendChild(li);
+        if (file.size <= 50 * 1024 * 1024) {
+            status.textContent = 'Tarama yapılıyor...';
+            scanFile(file).then(clean => {
+                status.textContent = clean ? 'Temiz' : 'Virüs bulundu';
+                scanStatuses.set(file.name, clean);
+                checkAllScans();
+            }).catch(() => {
+                status.textContent = 'Tarama hatası';
+                scanStatuses.set(file.name, false);
+                checkAllScans();
+            });
+        } else {
+            status.textContent = 'Tarama atlandı';
+            scanStatuses.set(file.name, true);
+            checkAllScans();
+        }
     }
+}
+
+function checkAllScans() {
+    if (scanStatuses.size === pendingFiles.length && [...scanStatuses.values()].every(v => v)) {
+        uploadBtn.classList.remove('d-none');
+    }
+}
+
+async function scanFile(file) {
+    const fd = new FormData();
+    fd.append('file', file);
+    const res = await fetch('/scan', { method: 'POST', body: fd });
+    const json = await res.json();
+    return json.clean;
 }
 
 async function handleUpload() {
@@ -912,61 +954,12 @@ async function handleUpload() {
         }
     }
     result.innerHTML += '<div class="alert alert-success">Dosyalar yüklendi</div>';
-    showShareOptions(uploaded, result, expiry);
     loadFiles();
     pendingFiles = [];
     fileList.innerHTML = '';
-}
-
-function showShareOptions(filenames, container, expiry) {
-    filenames.forEach(name => {
-        const div = document.createElement('div');
-        div.className = 'mt-2';
-        const label = document.createElement('span');
-        label.textContent = name;
-        const date = document.createElement('input');
-        date.type = 'date';
-        date.className = 'form-control d-inline-block w-auto ms-2';
-        date.value = expiry;
-        const userBtn = document.createElement('button');
-        userBtn.className = 'btn btn-sm btn-primary ms-2';
-        userBtn.textContent = 'Kullanıcıya Gönder';
-        userBtn.addEventListener('click', async () => {
-            shareFileName = name;
-            shareExpiry = date.value;
-            userModalMode = 'share-user';
-            const res = await fetch('/users/tree');
-            const json = await res.json();
-            const treeContainer = document.getElementById('ou-tree');
-            treeContainer.innerHTML = '';
-            renderTree(json.tree, treeContainer, username);
-            const modal = new bootstrap.Modal(document.getElementById('userModal'));
-            modal.show();
-        });
-        const teamBtn = document.createElement('button');
-        teamBtn.className = 'btn btn-sm btn-secondary ms-2';
-        teamBtn.textContent = 'Ekibe Gönder';
-        teamBtn.addEventListener('click', () => {
-            shareFileName = name;
-            shareExpiry = date.value;
-            teamModalMode = 'share-team';
-            const select = document.getElementById('team-select');
-            select.innerHTML = '';
-            teams.forEach(team => {
-                const opt = document.createElement('option');
-                opt.value = team.id;
-                opt.textContent = team.name;
-                select.appendChild(opt);
-            });
-            const modal = new bootstrap.Modal(document.getElementById('teamModal'));
-            modal.show();
-        });
-        div.appendChild(label);
-        div.appendChild(date);
-        div.appendChild(userBtn);
-        div.appendChild(teamBtn);
-        container.appendChild(div);
-    });
+    pendingTitle.classList.add('d-none');
+    scanStatuses.clear();
+    uploadBtn.classList.add('d-none');
 }
 
 async function uploadFile(file, expiry) {


### PR DESCRIPTION
## Summary
- Display validity label and pending file heading on upload screen, hiding upload button until virus scan completes.
- Send files under 50MB to VirusTotal for scanning and show size and scan status next to each pending file.
- Provide backend `/scan` endpoint and document `VT_API_KEY` configuration.

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689458a68400832b9d4005999e412e49