### PR TITLE
Replace VirusTotal with ClamAV scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ should contain a `{query}` placeholder that will be replaced with the incoming
 search text. By default the application uses
 `(&(objectClass=user)(sAMAccountName=*{query}*))`.
 
-For optional VirusTotal scanning of uploaded files, provide `VT_API_KEY` in the
-environment. Files smaller than 50MB will be scanned before the upload button
-appears.
+For optional ClamAV scanning of uploaded files, ensure the `clamscan` command is
+available in the backend container. Files smaller than 50MB will be scanned
+before the upload button appears.
 
 For public shares requiring manager approval, the backend sends an e-mail to the
 user's manager through the Microsoft Graph API. Configure the following variables:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11-slim
+RUN apt-get update && apt-get install -y clamav && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,8 @@
 import os
 import secrets
 import time
+import subprocess
+import tempfile
 from datetime import datetime, timedelta
 
 import msal
@@ -545,42 +547,31 @@ def scan_file():
     content = file.read()
     if len(content) > 50 * 1024 * 1024:
         return jsonify(success=True, clean=True)
-    api_key = os.getenv("VT_API_KEY")
-    if not api_key:
-        return jsonify(success=False, error="Missing API key"), 500
-    headers = {"x-apikey": api_key}
-    files = {"file": (file.filename, content)}
+
+    tmp_path = None
     try:
-        res = requests.post(
-            "https://www.virustotal.com/api/v3/files", headers=headers, files=files
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp.write(content)
+            tmp_path = tmp.name
+        result = subprocess.run(
+            ["clamscan", "--no-summary", tmp_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
-    except requests.RequestException:
+    except FileNotFoundError:
         return jsonify(success=False, error="scan failed"), 200
-    if res.status_code != 200:
-        return jsonify(success=False, error="scan failed"), 200
-    data = res.json()
-    analysis_id = data.get("data", {}).get("id")
-    if not analysis_id:
-        return jsonify(success=False, error="scan failed"), 200
-    analysis_url = f"https://www.virustotal.com/api/v3/analyses/{analysis_id}"
-    for _ in range(15):
-        try:
-            r = requests.get(analysis_url, headers=headers)
-        except requests.RequestException:
-            time.sleep(2)
-            continue
-        if r.status_code != 200:
-            time.sleep(2)
-            continue
-        data = r.json()
-        status = data.get("data", {}).get("attributes", {}).get("status")
-        if status != "completed":
-            time.sleep(2)
-            continue
-        stats = data["data"]["attributes"]["stats"]
-        clean = stats.get("malicious", 0) == 0 and stats.get("suspicious", 0) == 0
-        return jsonify(success=True, clean=clean)
-    return jsonify(success=False, error="analysis timeout"), 200
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+    if result.returncode == 0:
+        return jsonify(success=True, clean=True)
+    if result.returncode == 1:
+        return jsonify(success=True, clean=False)
+    return jsonify(success=False, error="scan failed"), 200
 
 
 @app.route("/upload", methods=["POST"])


### PR DESCRIPTION
## Summary
- Remove VirusTotal integration and add ClamAV-based scanning via `clamscan`
- Install ClamAV in backend image
- Document ClamAV scanning in README

## Testing
- `python -m py_compile backend/main.py`
- `pytest`
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689464bd9010832b8d0874a2c1acb3a5