### PR TITLE
Skip scanning when ClamAV is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ search text. By default the application uses
 
 For optional ClamAV scanning of uploaded files, ensure the `clamscan` command is
 available in the backend container. Files smaller than 50MB will be scanned
-before the upload button appears.
+before the upload button appears. If `clamscan` is not installed, scanning is
+skipped and uploads are allowed.
 
 For public shares requiring manager approval, the backend sends an e-mail to the
 user's manager through the Microsoft Graph API. Configure the following variables:

--- a/backend/main.py
+++ b/backend/main.py
@@ -559,7 +559,8 @@ def scan_file():
             stderr=subprocess.PIPE,
         )
     except FileNotFoundError:
-        return jsonify(success=False, error="scan failed"), 200
+        # clamscan not available; skip scanning
+        return jsonify(success=True, clean=True), 200
     finally:
         if tmp_path:
             try:


### PR DESCRIPTION
## Summary
- Ensure uploads proceed even if `clamscan` is not installed by treating missing scanner as a clean result
- Clarify in documentation that uploads are allowed when ClamAV is absent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689466c778b8832b9e66107ca03c1721