### PR TITLE
Remove antivirus scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ should contain a `{query}` placeholder that will be replaced with the incoming
 search text. By default the application uses
 `(&(objectClass=user)(sAMAccountName=*{query}*))`.
 
-For optional ClamAV scanning of uploaded files, ensure the `clamscan` command is
-available in the backend container. Files smaller than 50MB will be scanned
-before the upload button appears. If `clamscan` is not installed, scanning is
-skipped and uploads are allowed.
-
 For public shares requiring manager approval, the backend sends an e-mail to the
 user's manager through the Microsoft Graph API. Configure the following variables:
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.11-slim
-RUN apt-get update && apt-get install -y clamav && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,5 @@
 import os
 import secrets
-import time
-import subprocess
-import tempfile
 from datetime import datetime, timedelta
 
 import msal
@@ -537,43 +534,6 @@ def users_tree():
             conn.unbind()
         except Exception:
             pass
-
-
-@app.route("/scan", methods=["POST"])
-def scan_file():
-    file = request.files.get("file")
-    if not file:
-        return jsonify(success=False, error="No file"), 400
-    content = file.read()
-    if len(content) > 50 * 1024 * 1024:
-        return jsonify(success=True, clean=True)
-
-    tmp_path = None
-    try:
-        with tempfile.NamedTemporaryFile(delete=False) as tmp:
-            tmp.write(content)
-            tmp_path = tmp.name
-        result = subprocess.run(
-            ["clamscan", "--no-summary", tmp_path],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except FileNotFoundError:
-        # clamscan not available; skip scanning
-        return jsonify(success=True, clean=True), 200
-    finally:
-        if tmp_path:
-            try:
-                os.unlink(tmp_path)
-            except Exception:
-                pass
-
-    if result.returncode == 0:
-        return jsonify(success=True, clean=True)
-    if result.returncode == 1:
-        return jsonify(success=True, clean=False)
-    return jsonify(success=False, error="scan failed"), 200
-
 
 @app.route("/upload", methods=["POST"])
 def upload_file():

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -881,10 +881,7 @@ uploadBtn.addEventListener('click', handleUpload);
 const fileList = document.getElementById('file-list');
 const pendingTitle = document.getElementById('pending-title');
 let pendingFiles = [];
-const scanStatuses = new Map();
-
 function addFiles(files) {
-    uploadBtn.classList.add('d-none');
     if (pendingFiles.length === 0) {
         pendingTitle.classList.remove('d-none');
     }
@@ -893,44 +890,9 @@ function addFiles(files) {
         const li = document.createElement('li');
         li.className = 'list-group-item d-flex justify-content-between align-items-center';
         li.textContent = `${file.name} - ${formatSize(file.size)}`;
-        const status = document.createElement('span');
-        status.className = 'ms-2 text-muted';
-        li.appendChild(status);
         fileList.appendChild(li);
-        if (file.size <= 50 * 1024 * 1024) {
-            status.textContent = 'Tarama yapılıyor...';
-            scanFile(file).then(clean => {
-                status.textContent = clean ? 'Temiz' : 'Virüs bulundu';
-                scanStatuses.set(file.name, clean);
-                checkAllScans();
-            }).catch(() => {
-                status.textContent = 'Tarama hatası';
-                scanStatuses.set(file.name, false);
-                checkAllScans();
-            });
-        } else {
-            status.textContent = 'Tarama atlandı';
-            scanStatuses.set(file.name, true);
-            checkAllScans();
-        }
     }
-}
-
-function checkAllScans() {
-    if (scanStatuses.size === pendingFiles.length && [...scanStatuses.values()].every(v => v)) {
-        uploadBtn.classList.remove('d-none');
-    }
-}
-
-async function scanFile(file) {
-    const fd = new FormData();
-    fd.append('file', file);
-    const res = await fetch('/scan', { method: 'POST', body: fd });
-    const json = await res.json();
-    if (!res.ok || !json.success) {
-        throw new Error(json.error || 'Tarama başarısız');
-    }
-    return json.clean;
+    uploadBtn.classList.remove('d-none');
 }
 
 async function handleUpload() {
@@ -961,7 +923,6 @@ async function handleUpload() {
     pendingFiles = [];
     fileList.innerHTML = '';
     pendingTitle.classList.add('d-none');
-    scanStatuses.clear();
     uploadBtn.classList.add('d-none');
 }
 


### PR DESCRIPTION
## Summary
- Remove ClamAV scanning endpoint and related imports from backend.
- Drop pre-upload virus scanning from frontend file uploader.
- Simplify Dockerfile and docs by eliminating ClamAV installation and instructions.

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68946a125d50832bbc3f4df5919487a8