### PR TITLE
Restrict team user tree to BAYLAN OUs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -64,6 +64,8 @@ LDAP_BASE_DN = os.getenv("LDAP_BASE_DN", "")
 LDAP_SEARCH_FILTER = os.getenv(
     "LDAP_SEARCH_FILTER", "(&(objectClass=user)(sAMAccountName=*{query}*))"
 )
+# Only expose these OUs in the user selection tree
+ALLOWED_OUS = {"BAYLAN3", "BAYLAN4", "BAYLAN5"}
 
 GRAPH_TENANT_ID = os.getenv("GRAPH_TENANT_ID")
 GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID")
@@ -528,6 +530,7 @@ def users_tree():
         if not conn.bind():
             return jsonify(success=False, error="LDAP bağlantısı başarısız")
         tree = _build_ou_tree(conn, LDAP_BASE_DN)
+        tree = [node for node in tree if node["name"] in ALLOWED_OUS]
         return jsonify(tree=tree)
     except Exception as e:
         return jsonify(success=False, error=str(e))


### PR DESCRIPTION
## Summary
- show only BAYLAN3, BAYLAN4 and BAYLAN5 OUs and their users when choosing team members

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948109b07c832bbf3cee7cc0875bdf