### PR TITLE
Handle missing files in preview endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -829,6 +829,8 @@ def preview_file(token):
         if auth_resp:
             return auth_resp
         file_path = os.path.join(DATA_DIR, link.username, link.filename)
+        if not os.path.exists(file_path):
+            return "", 404
         if request.args.get("list") == "1":
             if zipfile.is_zipfile(file_path):
                 with zipfile.ZipFile(file_path) as zf:


### PR DESCRIPTION
## Summary
- avoid server errors in `/preview/<token>` by checking file existence

## Testing
- `python -m py_compile backend/main.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894936e88cc832bba14731912d9e528