### PR TITLE
Align file controls in a single row

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -77,18 +77,18 @@
 
         <section id="files">
             <h2>Dosyalarım</h2>
-            <div class="d-flex mb-2">
-                <input type="text" id="file-search" class="form-control me-2" placeholder="Ara...">
-                <select id="page-size" class="form-select" style="width:auto;">
+            <div class="d-flex align-items-center mb-2">
+                <button id="delete-selected" class="btn btn-danger me-2" disabled>Sil</button>
+                <button id="share-selected" class="btn btn-primary me-2" disabled>Kullanıcıya Gönder</button>
+                <button id="public-share" class="btn btn-outline-primary me-2" disabled>Paylaş</button>
+                <button id="add-to-team" class="btn btn-secondary me-2" disabled>Gruba Ekle</button>
+                <select id="page-size" class="form-select ms-auto me-2" style="width:auto;">
                     <option value="15" selected>15</option>
                     <option value="30">30</option>
                     <option value="100">100</option>
                 </select>
+                <input type="text" id="file-search" class="form-control" placeholder="Ara..." style="width:auto; max-width:200px;">
             </div>
-            <button id="delete-selected" class="btn btn-danger mb-2 me-2" disabled>Sil</button>
-            <button id="share-selected" class="btn btn-primary mb-2 me-2" disabled>Kullanıcıya Gönder</button>
-            <button id="public-share" class="btn btn-outline-primary mb-2 me-2" disabled>Paylaş</button>
-            <button id="add-to-team" class="btn btn-secondary mb-2" disabled>Gruba Ekle</button>
             <table id="file-table" class="table">
                 <thead>
                     <tr>


### PR DESCRIPTION
## Summary
- Keep file action buttons in existing order and place page size selector and search field alongside them in one flex row

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ba921f60832b8a1ae1cbf8c7f64d