### PR TITLE
Adjust file view control order

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -82,12 +82,12 @@
                 <button id="share-selected" class="btn btn-primary me-2" disabled>Kullanıcıya Gönder</button>
                 <button id="public-share" class="btn btn-outline-primary me-2" disabled>Paylaş</button>
                 <button id="add-to-team" class="btn btn-secondary me-2" disabled>Gruba Ekle</button>
-                <select id="page-size" class="form-select ms-auto me-2" style="width:auto;">
+                <input type="text" id="file-search" class="form-control ms-auto me-2" placeholder="Ara..." style="width:auto; max-width:200px;">
+                <select id="page-size" class="form-select" style="width:auto;">
                     <option value="15" selected>15</option>
                     <option value="30">30</option>
                     <option value="100">100</option>
                 </select>
-                <input type="text" id="file-search" class="form-control" placeholder="Ara..." style="width:auto; max-width:200px;">
             </div>
             <table id="file-table" class="table">
                 <thead>


### PR DESCRIPTION
## Summary
- Reorder file list search and page-size controls so search appears before paging selector

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bc1073fc832b94b5ebf3ce83602b