### PR TITLE
Set containers timezone to Istanbul

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   backend:
     build: ./backend
     env_file: ./backend/.env
+    environment:
+      TZ: Europe/Istanbul
     volumes:
       - ./data:/app/data
     ports:
@@ -15,6 +17,7 @@ services:
       POSTGRES_DB: filesharedb
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: secret
+      TZ: Europe/Istanbul
     volumes:
       - ./postgres:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
## Summary
- configure backend and postgres services to use Istanbul (UTC+3) timezone via TZ environment variable

## Testing
- `python -m py_compile backend/main.py`
- `docker compose config` *(fails: command not found)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_6895104d59d0832b8ee5097195b560e2