### PR TITLE
Sort file listings by upload date

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -705,6 +705,7 @@ def list_files():
                     "rejected": rejected,
                 }
             )
+        files.sort(key=lambda f: f["added"], reverse=True)
         return jsonify(files=files)
 
     db = SessionLocal()
@@ -761,6 +762,7 @@ def list_files():
                     "rejected": rejected,
                 }
             )
+    files.sort(key=lambda f: f["added"], reverse=True)
     return jsonify(files=files)
 
 


### PR DESCRIPTION
## Summary
- ensure `/list` endpoint returns files ordered by `added` timestamp
- apply ordering for both user and admin file listings

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f426079c832b899e84eb790aa43a