### PR TITLE
Enable admin approval for all pending shares

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -265,6 +265,7 @@ if (isAdmin) {
         adminBtn.textContent = adminMode ? 'Kullanıcı Modu' : 'Admin';
         loadFiles();
         loadTeams();
+        loadPending();
     });
 }
 
@@ -831,6 +832,9 @@ async function loadOutgoing() {
 async function loadPending() {
     const fd = new FormData();
     fd.append('username', username);
+    if (adminMode) {
+        fd.append('admin', '1');
+    }
     const res = await fetch('/share/pending', { method: 'POST', body: fd });
     const json = await res.json();
     const tbody = document.querySelector('#pending-table tbody');


### PR DESCRIPTION
## Summary
- Allow admins to approve any share link by extending manager auth
- Provide pending share list for admins
- Update frontend to fetch and display all pending shares in admin mode

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960272a9d8832ba789d16fe6d2c423