### PR TITLE
Adjust file search bar placement

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -82,7 +82,7 @@
                 <button id="share-selected" class="btn btn-primary me-2" disabled>Kullanıcıya Gönder</button>
                 <button id="public-share" class="btn btn-outline-primary me-2" disabled>Paylaş</button>
                 <button id="add-to-team" class="btn btn-secondary me-2" disabled>Gruba Ekle</button>
-                <input type="text" id="file-search" class="form-control ms-auto me-2" placeholder="Ara..." style="width:auto; max-width:200px;">
+                <input type="text" id="file-search" class="form-control me-2" placeholder="Ara..." style="width:auto; max-width:200px;">
                 <select id="page-size" class="form-select" style="width:auto;">
                     <option value="15" selected>15</option>
                     <option value="30">30</option>


### PR DESCRIPTION
## Summary
- Move file search bar next to the "Gruba Ekle" button by removing extra margin

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6896088a2ce0832bb0ce8e31aa13f2f6