### PR TITLE
Preserve UI state across auto refresh

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -299,6 +299,15 @@ function setCurrentPage(page) {
     currentPage = page;
     localStorage.setItem(PAGE_KEY, page);
 }
+const SECTION_KEY = 'currentSection';
+window.addEventListener('beforeunload', () => {
+    updateSelectedStorage();
+    localStorage.setItem(PAGE_KEY, currentPage);
+    const hash = window.location.hash ? window.location.hash.substring(1) : '';
+    if (hash) {
+        localStorage.setItem(SECTION_KEY, hash);
+    }
+});
 let currentSort = { field: null, dir: 1 };
 let teams = [];
 let currentTeamId = null;
@@ -493,6 +502,7 @@ function showSection(id) {
         section.classList.remove('d-none');
         if (id !== 'team-details') {
             window.location.hash = id;
+            localStorage.setItem(SECTION_KEY, id);
         }
         if (id === 'files') {
             loadFiles();
@@ -1176,7 +1186,7 @@ document.getElementById('team-form').addEventListener('submit', async (e) => {
 
 loadTeams();
 loadPending();
-const initialHash = window.location.hash ? window.location.hash.substring(1) : '';
+const initialHash = window.location.hash ? window.location.hash.substring(1) : (localStorage.getItem(SECTION_KEY) || '');
 if (initialHash.startsWith('team-')) {
     const teamId = initialHash.substring(5);
     viewTeam(teamId);


### PR DESCRIPTION
## Summary
- Store active section, selected files and pagination state in localStorage
- Restore last visited section on load to keep page and selections after auto refresh

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960a0fc82c832b9128e86562dab711