### PR TITLE
Persist checkbox selection across refresh

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -755,6 +755,11 @@ function renderFiles() {
 }
 
 async function loadFiles() {
+    // Restore persisted selections so auto-refresh preserves checkbox state
+    if (!adminMode) {
+        selected.clear();
+        JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]').forEach(v => selected.add(v));
+    }
     const formData = new FormData();
     formData.append('username', username);
     if (adminMode) {
@@ -767,11 +772,12 @@ async function loadFiles() {
         selected.clear();
         updateSelectedStorage();
     } else {
-        selected.forEach(value => {
-            if (!json.files.some(f => f.title === value)) {
+        const existing = new Set(json.files.map(f => f.title));
+        for (const value of Array.from(selected)) {
+            if (!existing.has(value)) {
                 selected.delete(value);
             }
-        });
+        }
         updateSelectedStorage();
     }
     renderFiles();


### PR DESCRIPTION
## Summary
- Restore stored selections when loading files so checkboxes stay checked after auto-refresh
- Keep only selections for existing files using a set intersection

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68960d0bbd78832b9eda43eda44baf1b