### PR TITLE
feat: introduce user activity tracking

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -25,6 +25,7 @@
                     <a class="nav-link" href="#teams"><i class="bi bi-people me-2"></i>Ekipler</a>
                     <ul id="team-menu" class="nav flex-column ms-3"></ul>
                 </li>
+                <li class="nav-item"><a class="nav-link" href="#activities"><i class="bi bi-clock-history me-2"></i>Aktiviteler</a></li>
             </ul>
         </div>
     </nav>
@@ -173,6 +174,19 @@
             <h3>Dosyalar</h3>
             <ul id="team-files-list" class="list-group"></ul>
         </section>
+        <section id="activities" class="d-none">
+            <h2>Aktiviteler</h2>
+            <table id="activities-table" class="table">
+                <thead>
+                    <tr>
+                        <th>Kullanıcı</th>
+                        <th>Mesaj</th>
+                        <th>Tarih</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
     </div>
 </div>
 
@@ -266,6 +280,7 @@ if (isAdmin) {
         loadFiles();
         loadTeams();
         loadPending();
+        loadActivities();
     });
 }
 
@@ -318,6 +333,7 @@ let shareFileNames = [];
 let shareExpiry = '';
 let currentFiles = [];
 let notifications = [];
+let activities = [];
 
 const sections = {
     upload: document.getElementById('upload'),
@@ -326,7 +342,8 @@ const sections = {
     outgoing: document.getElementById('outgoing'),
     pending: document.getElementById('pending'),
     teams: document.getElementById('teams'),
-    'team-details': document.getElementById('team-details')
+    'team-details': document.getElementById('team-details'),
+    activities: document.getElementById('activities')
 };
 
 searchInput.addEventListener('input', () => {
@@ -512,6 +529,8 @@ function showSection(id) {
             loadOutgoing();
         } else if (id === 'pending') {
             loadPending();
+        } else if (id === 'activities') {
+            loadActivities();
         }
     }
 }
@@ -926,6 +945,20 @@ async function loadPending() {
     }
 }
 
+async function loadActivities() {
+    const fd = new FormData();
+    fd.append('username', username);
+    const res = await fetch('/activities', { method: 'POST', body: fd });
+    const json = await res.json();
+    const tbody = document.querySelector('#activities-table tbody');
+    tbody.innerHTML = '';
+    json.activities.forEach(act => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${act.username}</td><td>${act.message}</td><td>${act.created_at}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
 deleteBtn.addEventListener('click', async () => {
     for (const value of selected) {
         const formData = new FormData();
@@ -1110,8 +1143,22 @@ async function viewTeam(teamId) {
     filesList.innerHTML = '';
     team.files.forEach(f => {
         const li = document.createElement('li');
-        li.className = 'list-group-item';
-        li.textContent = `${f.filename} (${f.username})`;
+        li.className = 'list-group-item d-flex justify-content-between align-items-center';
+        li.innerHTML = `<span>${f.filename} (${f.username})</span>`;
+        if (adminMode || f.username === username || team.creator === username) {
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-danger';
+            btn.innerHTML = '<i class="bi bi-trash"></i>';
+            btn.addEventListener('click', async () => {
+                const fd = new FormData();
+                fd.append('username', username);
+                fd.append('team_id', team.id);
+                fd.append('filename', f.filename);
+                await fetch('/teams/delete_file', { method: 'POST', body: fd });
+                viewTeam(team.id);
+            });
+            li.appendChild(btn);
+        }
         filesList.appendChild(li);
     });
     const container = document.getElementById('add-member-container');


### PR DESCRIPTION
## Summary
- add Activity database model and helper to record file downloads and team file changes
- expose `/activities` endpoint and log downloads and team uploads/deletes
- add UI menu and section for viewing activities

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e9fa8354832bbf89d96f5d914bc1