### PR TITLE
refactor: extract database and models into modules

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,53 @@
+import os
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+load_dotenv()
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql://admin:secret@postgres:5432/filesharedb"
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+def add_missing_columns():
+    inspector = inspect(engine)
+
+    team_cols = [col["name"] for col in inspector.get_columns("team_files")]
+    if "expires_at" not in team_cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE team_files ADD COLUMN expires_at TIMESTAMP"))
+
+    share_cols = [col["name"] for col in inspector.get_columns("share_links")]
+    if "expires_at" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN expires_at TIMESTAMP")
+            )
+    if "approved" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE share_links ADD COLUMN approved BOOLEAN DEFAULT FALSE"
+                )
+            )
+    if "rejected" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE share_links ADD COLUMN rejected BOOLEAN DEFAULT FALSE"
+                )
+            )
+
+    member_cols = [col["name"] for col in inspector.get_columns("team_members")]
+    if "accepted" not in member_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE team_members ADD COLUMN accepted BOOLEAN DEFAULT FALSE"
+                )
+            )

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, Boolean
+
+from database import Base, engine
+
+
+class ShareLink(Base):
+    __tablename__ = "share_links"
+
+    token = Column(String, primary_key=True, index=True)
+    username = Column(String, index=True)
+    filename = Column(String)
+    expires_at = Column(DateTime)
+    approved = Column(Boolean, default=False)
+    rejected = Column(Boolean, default=False)
+
+
+class DownloadLog(Base):
+    __tablename__ = "download_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True)
+    filename = Column(String)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+class Team(Base):
+    __tablename__ = "teams"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    creator = Column(String, index=True)
+
+
+class TeamMember(Base):
+    __tablename__ = "team_members"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), index=True)
+    username = Column(String, index=True)
+    accepted = Column(Boolean, default=False)
+
+
+class TeamFile(Base):
+    __tablename__ = "team_files"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), index=True)
+    username = Column(String, index=True)
+    filename = Column(String)
+    expires_at = Column(DateTime)
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True)
+    message = Column(String)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    read = Column(Boolean, default=False)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=True)
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True)
+    message = Column(String)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class UserShare(Base):
+    __tablename__ = "user_shares"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sender = Column(String, index=True)
+    recipient = Column(String, index=True)
+    filename = Column(String)
+    expires_at = Column(DateTime)
+
+
+class UserFile(Base):
+    __tablename__ = "user_files"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True)
+    filename = Column(String)
+    expires_at = Column(DateTime)
+
+
+Base.metadata.create_all(engine)


### PR DESCRIPTION
## Summary
- centralize database configuration and schema adjustments in `database.py`
- move SQLAlchemy ORM models into `models.py`
- streamline `main.py` to import shared database resources and models

## Testing
- `python -m py_compile main.py database.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_6896ecad0c88832b86d6eaeda4a9c669