### PR TITLE
Fix incorrect 'rejected' status on newly uploaded files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -621,6 +621,7 @@ def list_files():
                 }
                 for l in db.query(ShareLink)
                 .filter_by(username=username)
+                .filter(ShareLink.rejected == False)
                 .filter((ShareLink.expires_at == None) | (ShareLink.expires_at > now))
                 .all()
             }
@@ -673,6 +674,7 @@ def list_files():
                 "rejected": l.rejected,
             }
             for l in db.query(ShareLink)
+            .filter(ShareLink.rejected == False)
             .filter((ShareLink.expires_at == None) | (ShareLink.expires_at > now))
             .all()
         }


### PR DESCRIPTION
## Summary
- Ignore rejected share links when gathering file metadata
- Prevents previously rejected shares from marking unrelated uploads as rejected

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f7a2cb8c832bb108dfc4c33b8664