### PR TITLE
Ensure notifications store UTC+3 timestamps

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -57,7 +57,9 @@ class Notification(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, index=True)
     message = Column(String)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(
+        DateTime, default=lambda: datetime.utcnow() + timedelta(hours=3)
+    )
     read = Column(Boolean, default=False)
     team_id = Column(Integer, ForeignKey("teams.id"), nullable=True)
 


### PR DESCRIPTION
## Summary
- store notification timestamps in UTC+3 to display local time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973123018c832b959ea78a13518183