### PR TITLE
Show download counts with detailed logs for shared files

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -260,6 +260,25 @@
   </div>
 </div>
 
+<div class="modal fade" id="downloadLogModal" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">İndirme Geçmişi</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <table class="table">
+          <thead>
+            <tr><th>Tarih</th><th>IP Adresi</th><th>Ülke</th></tr>
+          </thead>
+          <tbody id="download-log-body"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div id="notif-overlay" class="position-fixed top-0 start-0 w-100 h-100 d-none" style="background: rgba(0, 0, 0, 0.2); z-index:900;"></div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -757,6 +776,11 @@ function renderFiles() {
                 setTimeout(() => msg.remove(), 2000);
             });
             titleTd.appendChild(linkBtn);
+            const dlBtn = document.createElement('button');
+            dlBtn.className = 'btn btn-sm btn-outline-secondary ms-2';
+            dlBtn.textContent = `${file.download_count} İndirme`;
+            dlBtn.addEventListener('click', () => showDownloadLogs(file));
+            titleTd.appendChild(dlBtn);
         }
         tr.appendChild(titleTd);
 
@@ -810,6 +834,40 @@ async function loadFiles() {
     if (json.files.some(f => f.link && !f.approved)) {
         setTimeout(loadFiles, 5000);
     }
+}
+
+async function showDownloadLogs(file) {
+    const fd = new FormData();
+    fd.append('username', adminMode ? file.username : username);
+    fd.append('filename', file.title);
+    const res = await fetch('/download/logs', { method: 'POST', body: fd });
+    const json = await res.json();
+    const tbody = document.getElementById('download-log-body');
+    tbody.innerHTML = '';
+    json.logs.forEach(log => {
+        const tr = document.createElement('tr');
+        const tsTd = document.createElement('td');
+        tsTd.textContent = log.timestamp;
+        tr.appendChild(tsTd);
+        const ipTd = document.createElement('td');
+        ipTd.textContent = log.ip_address;
+        tr.appendChild(ipTd);
+        const countryTd = document.createElement('td');
+        countryTd.textContent = log.country;
+        tr.appendChild(countryTd);
+        tbody.appendChild(tr);
+    });
+    if (json.logs.length === 0) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 3;
+        td.className = 'text-center';
+        td.textContent = 'Kayıt yok';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    }
+    const modal = new bootstrap.Modal(document.getElementById('downloadLogModal'));
+    modal.show();
 }
 
 async function loadIncoming() {


### PR DESCRIPTION
## Summary
- track download counts for each file and expose a `/download/logs` API returning timestamp, IP and country in UTC+3
- show a download count button next to public share links and display log details in a modal

## Testing
- `python -m py_compile main.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_689737988b88832b8079bb5c1d8ce7f4