### PR TITLE
Fix admin download count lookup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -746,8 +746,8 @@ def list_files():
             .all()
         }
         counts = {
-            (dl.username, dl.filename): cnt
-            for dl.username, dl.filename, cnt in db.query(
+            (username, filename): cnt
+            for username, filename, cnt in db.query(
                 DownloadLog.username,
                 DownloadLog.filename,
                 func.count(),


### PR DESCRIPTION
## Summary
- fix admin mode download count query that raised NameError by using proper tuple unpacking and iteration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68973a23f774832ba767d3e9a0731a43