### PR TITLE
Ensure cookies are sent with fetch requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,7 +39,7 @@ add_missing_columns()
 
 app = Flask(__name__)
 app.secret_key = os.getenv("FLASK_SECRET_KEY", "super-secret-key")
-CORS(app)
+CORS(app, supports_credentials=True)
 
 DATA_DIR = "data"
 os.makedirs(DATA_DIR, exist_ok=True)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -288,6 +288,14 @@ if (!username) {
     window.location.href = '/login';
 }
 
+const _fetch = window.fetch.bind(window);
+window.fetch = (url, options = {}) => {
+    if (!options.credentials) {
+        options.credentials = 'include';
+    }
+    return _fetch(url, options);
+};
+
 const isAdmin = localStorage.getItem('admin') === '1';
 const adminBtn = document.getElementById('admin-btn');
 const ADMIN_MODE_KEY = 'adminMode';

--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -33,6 +33,13 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+const _fetch = window.fetch.bind(window);
+window.fetch = (url, options = {}) => {
+    if (!options.credentials) {
+        options.credentials = 'include';
+    }
+    return _fetch(url, options);
+};
 const params = new URLSearchParams(window.location.search);
 const next = params.get('next');
 document.getElementById('login-form').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- Default all browser fetch calls to include cookies
- Allow CORS requests to carry credentials

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689793b421a0832bb6c351c3d33f53ab