### PR TITLE
Display login activities within activities section

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -26,7 +26,6 @@
                     <ul id="team-menu" class="nav flex-column ms-3"></ul>
                 </li>
                 <li class="nav-item"><a class="nav-link" href="#activities"><i class="bi bi-clock-history me-2"></i>Aktiviteler</a></li>
-                <li class="nav-item d-none" id="logins-menu-item"><a class="nav-link" href="#logins"><i class="bi bi-box-arrow-in-right me-2"></i>Girişler</a></li>
             </ul>
         </div>
     </nav>
@@ -187,8 +186,6 @@
                 </thead>
                 <tbody></tbody>
             </table>
-        </section>
-        <section id="logins" class="d-none">
             <h2>Kullanıcı Girişleri</h2>
             <table id="login-activities-table" class="table">
                 <thead>
@@ -328,7 +325,6 @@ function updateSelectedStorage() {
 }
 if (isAdmin) {
     adminBtn.classList.remove('d-none');
-    document.getElementById('logins-menu-item').classList.remove('d-none');
     adminBtn.textContent = adminMode ? 'Kullanıcı Modu' : 'Admin';
     adminBtn.addEventListener('click', () => {
         updateSelectedStorage();
@@ -339,7 +335,6 @@ if (isAdmin) {
         loadTeams();
         loadPending();
         loadActivities();
-        loadLogins();
     });
 } else {
     adminMode = false;
@@ -390,7 +385,6 @@ let shareExpiry = '';
 let currentFiles = [];
 let notifications = [];
 let activities = [];
-let loginActivities = [];
 
 const sections = {
     upload: document.getElementById('upload'),
@@ -400,8 +394,7 @@ const sections = {
     pending: document.getElementById('pending'),
     teams: document.getElementById('teams'),
     'team-details': document.getElementById('team-details'),
-    activities: document.getElementById('activities'),
-    logins: document.getElementById('logins')
+    activities: document.getElementById('activities')
 };
 
 searchInput.addEventListener('input', () => {
@@ -589,8 +582,6 @@ function showSection(id) {
             loadPending();
         } else if (id === 'activities') {
             loadActivities();
-        } else if (id === 'logins') {
-            loadLogins();
         }
     }
 }
@@ -1050,6 +1041,7 @@ async function loadActivities() {
         tr.innerHTML = `<td>${act.username}</td><td>${act.message}</td><td>${act.created_at}</td>`;
         tbody.appendChild(tr);
     });
+    await loadLogins();
 }
 
 async function loadLogins() {
@@ -1057,7 +1049,6 @@ async function loadLogins() {
     fd.append('username', username);
     const res = await fetch('/login-activities', { method: 'POST', body: fd });
     const json = await res.json();
-    loginActivities = json.activities;
     const tbody = document.querySelector('#login-activities-table tbody');
     tbody.innerHTML = '';
     json.activities.forEach(act => {


### PR DESCRIPTION
## Summary
- Show login-related records under Activities instead of a separate Girişler menu
- Load login activity data when viewing Activities

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68979a5b207c832b896d94955ce2b0a8