### PR TITLE
Display login events within activities list

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1784,30 +1784,6 @@ def activities():
         db.close()
 
 
-@app.route("/login-activities", methods=["POST"])
-def login_activities():
-    username = request.form.get("username")
-    db = SessionLocal()
-    try:
-        query = (
-            db.query(Activity)
-            .filter_by(category="login")
-            .order_by(Activity.created_at.desc())
-        )
-        if not is_admin(username):
-            query = query.filter_by(username=username)
-        acts = query.all()
-        data = [
-            {
-                "username": a.username,
-                "created_at": a.created_at.strftime("%Y-%m-%d %H:%M"),
-            }
-            for a in acts
-        ]
-        return jsonify(activities=data)
-    finally:
-        db.close()
-
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -186,16 +186,6 @@
                 </thead>
                 <tbody></tbody>
             </table>
-            <h2>Kullanıcı Girişleri</h2>
-            <table id="login-activities-table" class="table">
-                <thead>
-                    <tr>
-                        <th>Kullanıcı</th>
-                        <th>Tarih</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
         </section>
     </div>
 </div>
@@ -1039,21 +1029,6 @@ async function loadActivities() {
     json.activities.forEach(act => {
         const tr = document.createElement('tr');
         tr.innerHTML = `<td>${act.username}</td><td>${act.message}</td><td>${act.created_at}</td>`;
-        tbody.appendChild(tr);
-    });
-    await loadLogins();
-}
-
-async function loadLogins() {
-    const fd = new FormData();
-    fd.append('username', username);
-    const res = await fetch('/login-activities', { method: 'POST', body: fd });
-    const json = await res.json();
-    const tbody = document.querySelector('#login-activities-table tbody');
-    tbody.innerHTML = '';
-    json.activities.forEach(act => {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${act.username}</td><td>${act.created_at}</td>`;
         tbody.appendChild(tr);
     });
 }


### PR DESCRIPTION
## Summary
- Remove separate "Kullanıcı Girişleri" table from activities page
- Eliminate unused `/login-activities` endpoint and associated frontend calls

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_689857a4d4bc832bb0fc831f5c5dc58f