### PR TITLE
Clean activity messages and show categories

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -147,7 +147,11 @@ def log_activity(usernames, message: str, category: str = "general"):
     db = SessionLocal()
     try:
         for u in usernames:
-            db.add(Activity(username=u, message=message, category=category))
+            msg = message
+            prefix = f"{u} kullanıcısı "
+            if msg.startswith(prefix):
+                msg = msg[len(prefix):]
+            db.add(Activity(username=u, message=msg, category=category))
         db.commit()
     finally:
         db.close()
@@ -1770,15 +1774,20 @@ def activities():
         if not is_admin(username):
             query = query.filter_by(username=username)
         acts = query.all()
-        data = [
-            {
-                "username": a.username,
-                "message": a.message,
-                "category": a.category,
-                "created_at": a.created_at.strftime("%Y-%m-%d %H:%M"),
-            }
-            for a in acts
-        ]
+        data = []
+        for a in acts:
+            msg = a.message
+            prefix = f"{a.username} kullanıcısı "
+            if msg.startswith(prefix):
+                msg = msg[len(prefix):]
+            data.append(
+                {
+                    "username": a.username,
+                    "message": msg,
+                    "category": a.category,
+                    "created_at": a.created_at.strftime("%Y-%m-%d %H:%M"),
+                }
+            )
         return jsonify(activities=data)
     finally:
         db.close()

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -181,6 +181,7 @@
                     <tr>
                         <th>Kullanıcı</th>
                         <th>Mesaj</th>
+                        <th>Kategori</th>
                         <th>Tarih</th>
                     </tr>
                 </thead>
@@ -1028,7 +1029,7 @@ async function loadActivities() {
     tbody.innerHTML = '';
     json.activities.forEach(act => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${act.username}</td><td>${act.message}</td><td>${act.created_at}</td>`;
+        tr.innerHTML = `<td>${act.username}</td><td>${act.message}</td><td>${act.category}</td><td>${act.created_at}</td>`;
         tbody.appendChild(tr);
     });
 }


### PR DESCRIPTION
## Summary
- Strip redundant username prefix when logging activities and when fetching them
- Expose activity categories in the UI and populate table with cleaned messages

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68985aa0a2fc832b8b5dc1e1fbca120d