### PR TITLE
Add preview support for common file types

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,21 @@ from datetime import datetime, timedelta
 import mimetypes
 import zipfile
 
+# Ensure previewed file types have proper MIME types
+mimetypes.add_type("image/png", ".png")
+mimetypes.add_type("image/jpeg", ".jpg")
+mimetypes.add_type("image/jpeg", ".jpeg")
+mimetypes.add_type("application/vnd.ms-excel", ".xls")
+mimetypes.add_type(
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", ".xlsx"
+)
+mimetypes.add_type("application/msword", ".doc")
+mimetypes.add_type(
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".docx",
+)
+mimetypes.add_type("text/csv", ".csv")
+
 import msal
 import requests
 

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -956,8 +956,9 @@ async function loadPending() {
         fileTd.appendChild(nameSpan);
 
         const ext = item.filename.split('.').pop().toLowerCase();
-        const previewable = ['pdf'];
+        const previewable = ['pdf', 'png', 'jpg', 'jpeg', 'xls', 'xlsx', 'doc', 'docx', 'csv'];
         const archiveExts = ['zip', 'rar', 'tar', 'gz', 'tgz', 'tar.gz'];
+        const imageExts = ['png', 'jpg', 'jpeg'];
         if (previewable.includes(ext) || archiveExts.includes(ext)) {
             const btn = document.createElement('button');
             btn.className = 'btn btn-sm btn-outline-secondary ms-2';
@@ -969,6 +970,15 @@ async function loadPending() {
                     const res = await fetch(`/preview/${item.token}?list=1`);
                     const data = await res.json();
                     modalContent.innerHTML = `<ul class="mb-0">${data.files.map(f => `<li>${f}</li>`).join('')}</ul>`;
+                } else if (imageExts.includes(ext)) {
+                    modalContent.innerHTML = `<img src="/preview/${item.token}" class="img-fluid" />`;
+                } else if (ext === 'csv') {
+                    const res = await fetch(`/preview/${item.token}`);
+                    const text = await res.text();
+                    const pre = document.createElement('pre');
+                    pre.className = 'mb-0';
+                    pre.textContent = text;
+                    modalContent.appendChild(pre);
                 } else {
                     modalContent.innerHTML = `<iframe src="/preview/${item.token}" style="width:100%;height:400px;"></iframe>`;
                 }


### PR DESCRIPTION
## Summary
- Support previewing additional document and image types on pending share requests
- Register MIME types for new previewable formats in backend

## Testing
- `python -m py_compile backend/main.py backend/database.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_6899934791b4832baf1680cfd83584fd