### PR TITLE
Enable preview for Microsoft Office documents

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,11 @@ mimetypes.add_type(
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".docx",
 )
+mimetypes.add_type("application/vnd.ms-powerpoint", ".ppt")
+mimetypes.add_type(
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".pptx",
+)
 mimetypes.add_type("text/csv", ".csv")
 
 import msal

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -956,9 +956,10 @@ async function loadPending() {
         fileTd.appendChild(nameSpan);
 
         const ext = item.filename.split('.').pop().toLowerCase();
-        const previewable = ['pdf', 'png', 'jpg', 'jpeg', 'xls', 'xlsx', 'doc', 'docx', 'csv'];
+        const previewable = ['pdf', 'png', 'jpg', 'jpeg', 'xls', 'xlsx', 'doc', 'docx', 'ppt', 'pptx', 'csv'];
         const archiveExts = ['zip', 'rar', 'tar', 'gz', 'tgz', 'tar.gz'];
         const imageExts = ['png', 'jpg', 'jpeg'];
+        const officeExts = ['xls', 'xlsx', 'doc', 'docx', 'ppt', 'pptx'];
         if (previewable.includes(ext) || archiveExts.includes(ext)) {
             const btn = document.createElement('button');
             btn.className = 'btn btn-sm btn-outline-secondary ms-2';
@@ -979,6 +980,9 @@ async function loadPending() {
                     pre.className = 'mb-0';
                     pre.textContent = text;
                     modalContent.appendChild(pre);
+                } else if (officeExts.includes(ext)) {
+                    const fileUrl = encodeURIComponent(`${window.location.origin}/preview/${item.token}`);
+                    modalContent.innerHTML = `<iframe src="https://view.officeapps.live.com/op/embed.aspx?src=${fileUrl}" style="width:100%;height:400px;" frameborder="0"></iframe>`;
                 } else {
                     modalContent.innerHTML = `<iframe src="/preview/${item.token}" style="width:100%;height:400px;"></iframe>`;
                 }


### PR DESCRIPTION
## Summary
- include ppt and pptx MIME types to avoid forced downloads
- embed Office web viewer for doc, xls, and ppt formats

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689996166f70832ba8f8b0098dcc688f