### PR TITLE
feat: integrate OnlyOffice editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ docker-compose up --build
 ```
 
 The application will be available at `http://localhost:8080/`.
+An OnlyOffice Document Server is also started for collaborative editing at
+`http://localhost:8081/`.
 
 ## Configuration
 
@@ -27,3 +29,13 @@ user's manager through the Microsoft Graph API. Configure the following variable
 - `GRAPH_CLIENT_ID`
 - `GRAPH_CLIENT_SECRET`
 - `GRAPH_SENDER` for the account used to send mail
+
+### OnlyOffice
+
+The backend integrates with an OnlyOffice Document Server. To change the URLs
+used for the editor or internal callbacks, set:
+
+- `ONLYOFFICE_URL` – external URL of the Document Server (default:
+  `http://localhost:8081`)
+- `ONLYOFFICE_INTERNAL_URL` – URL used by the Document Server to reach the
+  backend (default: `http://backend:8000`)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1229,7 +1229,18 @@ async function viewTeam(teamId) {
     team.files.forEach(f => {
         const li = document.createElement('li');
         li.className = 'list-group-item d-flex justify-content-between align-items-center';
-        li.innerHTML = `<span>${f.filename} (${f.username})</span>`;
+        const span = document.createElement('span');
+        span.textContent = `${f.filename} (${f.username})`;
+        li.appendChild(span);
+        const actions = document.createElement('div');
+        const editBtn = document.createElement('button');
+        editBtn.className = 'btn btn-sm btn-primary me-2';
+        editBtn.innerHTML = '<i class="bi bi-pencil"></i>';
+        editBtn.addEventListener('click', () => {
+            const url = `/teams/edit?username=${username}&team_id=${team.id}&filename=${encodeURIComponent(f.filename)}`;
+            window.open(url, '_blank');
+        });
+        actions.appendChild(editBtn);
         if (adminMode || f.username === username || team.creator === username) {
             const btn = document.createElement('button');
             btn.className = 'btn btn-sm btn-danger';
@@ -1242,8 +1253,9 @@ async function viewTeam(teamId) {
                 await fetch('/teams/delete_file', { method: 'POST', body: fd });
                 viewTeam(team.id);
             });
-            li.appendChild(btn);
+            actions.appendChild(btn);
         }
+        li.appendChild(actions);
         filesList.appendChild(li);
     });
     const container = document.getElementById('add-member-container');

--- a/backend/templates/editor.html
+++ b/backend/templates/editor.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="{{ onlyoffice_url }}/web-apps/apps/api/documents/api.js"></script>
+</head>
+<body>
+  <div id="editor" style="width:100%; height:100vh;"></div>
+  <script>
+    var docEditor = new DocsAPI.DocEditor("editor", {{ config|safe }});
+  </script>
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,12 @@ services:
     ports:
       - "5432:5432"
     restart: always
+
+  onlyoffice:
+    image: onlyoffice/documentserver:latest
+    environment:
+      - JWT_ENABLED=false
+      - TZ=Europe/Istanbul
+    ports:
+      - "8081:80"
+    restart: always


### PR DESCRIPTION
## Summary
- add OnlyOffice Document Server to docker-compose for collaborative editing
- expose new backend routes and editor template to edit team files in OnlyOffice and log changes
- add team file edit buttons and document server configuration docs

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899b0e71fe8832baa664605cc4b8126