### PR TITLE
Integrate JWT security for OnlyOffice editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ used for the editor or internal callbacks, set:
   `http://localhost:8081`)
 - `ONLYOFFICE_INTERNAL_URL` – URL used by the Document Server to reach the
   backend (default: `http://backend:8000`)
+- `ONLYOFFICE_JWT_SECRET` – shared secret for signing OnlyOffice requests. The
+  same value must be provided to the Document Server via `JWT_SECRET`.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ pycryptodome
 jinja2
 msal
 requests
+PyJWT
 python-docx
 openpyxl
 python-pptx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     env_file: ./backend/.env
     environment:
       TZ: Europe/Istanbul
+      ONLYOFFICE_JWT_SECRET: ${ONLYOFFICE_JWT_SECRET:-secret}
     volumes:
       - ./data:/app/data
     ports:
@@ -27,7 +28,8 @@ services:
   onlyoffice:
     image: onlyoffice/documentserver:latest
     environment:
-      - JWT_ENABLED=false
+      - JWT_ENABLED=true
+      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET:-secret}
       - TZ=Europe/Istanbul
     ports:
       - "8081:80"


### PR DESCRIPTION
## Summary
- Sign OnlyOffice editor configuration with a shared `ONLYOFFICE_JWT_SECRET` and verify incoming callbacks and file requests.
- Enable JWT for the Document Server and expose the shared secret to the backend via docker-compose.
- Document the new secret in README and add PyJWT dependency.

## Testing
- `python -m py_compile backend/main.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_6899b729885c832ba2c816d5c34b9681