### PR TITLE
Handle login usernames case-insensitively

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -284,10 +284,11 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-const username = localStorage.getItem('username');
+const username = (localStorage.getItem('username') || '').toLowerCase();
 if (!username) {
     window.location.href = '/login';
 }
+localStorage.setItem('username', username);
 
 const _fetch = window.fetch.bind(window);
 window.fetch = (url, options = {}) => {

--- a/backend/templates/login.html
+++ b/backend/templates/login.html
@@ -49,7 +49,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     const res = await fetch('/login', { method: 'POST', body: data });
     const json = await res.json();
     if (json.success) {
-        localStorage.setItem('username', data.get('username'));
+        localStorage.setItem('username', data.get('username').toLowerCase());
         if (json.givenName) {
             localStorage.setItem('name', json.givenName);
         }


### PR DESCRIPTION
## Summary
- Normalize stored usernames to lowercase on login
- Force lowercase usernames when retrieving from browser storage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a01301e48832baf7ca2f1fb81c716