### PR TITLE
Add Nginx reverse proxy for internal and public domains

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,16 @@ services:
       TZ: Europe/Istanbul
     volumes:
       - ./data:/app/data
+    restart: always
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "8080:8000"
+      - "80:80"
+    depends_on:
+      - backend
     restart: always
 
   postgres:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,49 @@
+events {}
+
+http {
+    server {
+        listen 80;
+        server_name send.baylan.local;
+
+        location / {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 80;
+        server_name send.baylan.info.tr;
+
+        location ^~ /download.php {
+            proxy_pass http://10.10.10.21;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ^~ /public/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ^~ /static/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            return 403;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Nginx service to route `send.baylan.local` to the backend
- Expose only `/public` and static resources on `send.baylan.info.tr`, proxying old `/download.php` links to `10.10.10.21`

## Testing
- `docker compose config` *(fails: command not found)*
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a40670fa0832ba690e8c0bfbf3847