### PR TITLE
Add server-side logout to prevent redirect loop

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -524,6 +524,20 @@ def login():
         return jsonify(success=False, error=str(e))
 
 
+@app.route("/logout", methods=["POST"])
+def logout():
+    """Clear the user session and log the logout event."""
+    username = session.pop("username", None)
+    if username:
+        log_activity(
+            username,
+            f"{username} kullanıcısı sistemden çıktı",
+            "logout",
+        )
+    session.clear()
+    return jsonify(success=True)
+
+
 @app.route("/users/list", methods=["GET"])
 def list_users():
     query = request.args.get("q", "")

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -335,7 +335,8 @@ loadSelected();
 
 const displayName = localStorage.getItem('name') || username;
 document.getElementById('username-display').textContent = displayName;
-document.getElementById('logout-btn').addEventListener('click', () => {
+document.getElementById('logout-btn').addEventListener('click', async () => {
+    await fetch('/logout', { method: 'POST' });
     localStorage.removeItem('username');
     localStorage.removeItem('name');
     localStorage.removeItem('selectedFiles');


### PR DESCRIPTION
## Summary
- add `/logout` endpoint to clear user session and log logout events
- call new endpoint from frontend logout button

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689a5036bb98832b99e6f3cc9949ad5d