### PR TITLE
Handle non-JSON upload responses

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1560,8 +1560,13 @@ async function uploadFile(file, expiry, description) {
         formData.append('file', chunk);
         formData.append('description', description);
         const res = await fetch('/upload', { method: 'POST', body: formData });
+        const contentType = res.headers.get('Content-Type') || '';
+        if (!contentType.includes('application/json')) {
+            const text = await res.text();
+            throw new Error(text || 'Yükleme başarısız');
+        }
         const json = await res.json();
-        if (!json.success) {
+        if (!res.ok || !json.success) {
             throw new Error(json.error || 'Yükleme başarısız');
         }
         if (json.filenames && json.filenames.length > 0) {


### PR DESCRIPTION
## Summary
- Ensure file uploads handle unexpected HTML/error responses
- Provide clearer error messages when server returns non-JSON

## Testing
- `python -m py_compile backend/main.py backend/database.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_689af46dc8a4832bb7fbd11780aa08aa