### PR TITLE
Increase upload limit to 1GB

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,7 @@
 events {}
 
 http {
+    client_max_body_size 1g;
     server {
         listen 80;
         server_name send.baylan.local;


### PR DESCRIPTION
## Summary
- raise Nginx upload limit to 1 GB
- enforce 1 GB upload cap in Flask backend

## Testing
- `python -m py_compile backend/main.py`
- `pytest`
- `nginx -t -c $(pwd)/nginx/nginx.conf` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.)*

------
https://chatgpt.com/codex/tasks/task_e_689af73dce00832bbfa99804e128b888