### PR TITLE
Make sidebar resizable without wrapping text

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -49,11 +49,29 @@
         white-space: nowrap;
         text-align: center;
     }
+    #sidebar {
+        width: 250px;
+        min-width: 150px;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+    #sidebar .nav-link {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    #sidebar-resizer {
+        width: 5px;
+        cursor: col-resize;
+        background-color: #dee2e6;
+        flex-shrink: 0;
+        height: 100vh;
+    }
     </style>
 </head>
 <body>
 <div class="d-flex">
-    <nav id="sidebar" class="bg-light border-end vh-100 flex-shrink-0" style="width: 250px;">
+    <nav id="sidebar" class="bg-light border-end vh-100 flex-shrink-0">
         <div class="p-3">
             <img src="/static/logo-small.png" alt="Logo" class="img-fluid mb-3 mx-auto d-block" style="max-width: 120px;">
             <ul class="nav flex-column">
@@ -74,7 +92,7 @@
             </ul>
         </div>
     </nav>
-
+    <div id="sidebar-resizer"></div>
     <div class="flex-grow-1 p-3">
         <div class="d-flex align-items-center mb-3 position-relative">
             <h1 class="me-3 mb-0">Hoş geldin, <span id="username-display"></span></h1>
@@ -1721,6 +1739,27 @@ function createProgressBar(filename) {
     container.appendChild(progress);
     document.getElementById('upload-result').appendChild(container);
     return bar;
+}
+
+// Sidebar resizing
+const sidebar = document.getElementById('sidebar');
+const sidebarResizer = document.getElementById('sidebar-resizer');
+let startX, startWidth;
+sidebarResizer.addEventListener('mousedown', (e) => {
+    startX = e.clientX;
+    startWidth = sidebar.offsetWidth;
+    document.addEventListener('mousemove', resizeSidebar);
+    document.addEventListener('mouseup', stopResize);
+});
+
+function resizeSidebar(e) {
+    const newWidth = Math.max(150, startWidth + e.clientX - startX);
+    sidebar.style.width = newWidth + 'px';
+}
+
+function stopResize() {
+    document.removeEventListener('mousemove', resizeSidebar);
+    document.removeEventListener('mouseup', stopResize);
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Allow left sidebar width to be adjusted with a drag handle
- Prevent sidebar text from wrapping onto multiple lines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1688840c832b89408b6325ab5997