### PR TITLE
Center notification dropdown

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -99,7 +99,7 @@
             <div class="me-3 position-relative" id="notif-container" style="cursor:pointer;">
                 <i id="notif-bell" class="bi bi-bell" style="font-size:1.5rem;"></i>
                 <span id="notif-count" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger d-none"></span>
-                <div id="notif-list" class="position-absolute bg-white border rounded d-none p-2" style="top:2rem; right:0; z-index:1000; max-height:600px; width:600px; overflow:auto; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+                <div id="notif-list" class="position-absolute bg-white border rounded d-none p-2" style="top:2rem; left:50%; transform:translateX(-50%); z-index:1000; max-height:600px; width:600px; overflow:auto; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
                     <i id="notif-clear" class="bi bi-x-circle-fill text-secondary position-absolute" style="top:4px; right:4px; cursor:pointer;"></i>
                     <table class="table table-sm mb-0 mt-4">
                         <thead>


### PR DESCRIPTION
## Summary
- Center the notification dropdown beneath the bell icon so its middle aligns with the bell, preventing left overflow on short usernames.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b19c6ee20832b8412b0315dc12659