### PR TITLE
Add dashboard with usage statistics

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -75,6 +75,7 @@
         <div class="p-3">
             <img src="/static/logo-small.png" alt="Logo" class="img-fluid mb-3 mx-auto d-block" style="max-width: 120px;">
             <ul class="nav flex-column">
+                <li class="nav-item"><a class="nav-link" href="#dashboard"><i class="bi bi-speedometer2 me-2"></i>Dashboard</a></li>
                 <li class="nav-item"><a class="nav-link" href="#upload"><i class="bi bi-upload me-2"></i>Yükle</a></li>
                 <li class="nav-item">
                     <a class="nav-link" href="#files"><i class="bi bi-folder2-open me-2"></i>Dosyalarım</a>
@@ -117,7 +118,32 @@
             <button id="logout-btn" class="btn btn-outline-secondary btn-sm">Çıkış</button>
         </div>
 
-        <section id="upload" class="mb-4 d-none" style="max-width: 50%;">
+          <section id="dashboard" class="mb-4">
+            <h2>Dashboard</h2>
+            <div class="mb-4">
+              <h3>Disk Kullanımı</h3>
+              <canvas id="disk-chart" width="400" height="400"></canvas>
+              <div class="text-center mt-2"><strong>Toplam: <span id="disk-total"></span></strong></div>
+            </div>
+            <div class="mb-4">
+              <h3>İndirmeler</h3>
+              <p>En çok indirilen dosya: <span id="top-file"></span></p>
+              <p>En çok indirilen ülke: <span id="top-country"></span></p>
+            </div>
+            <div class="mb-4">
+              <h3>Ekipler</h3>
+              <ul id="dashboard-teams" class="list-group"></ul>
+            </div>
+            <div class="mb-4">
+              <h3>Süresi Yaklaşan Dosyalar</h3>
+              <table class="table" id="expiring-table">
+                <thead><tr><th>Dosya</th><th>Kalan Gün</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section id="upload" class="mb-4 d-none" style="max-width: 50%;">
             <h2>Dosya Yükle</h2>
             <div id="drop-zone" class="mb-2 border border-primary rounded p-5 text-center w-100" style="cursor: pointer;">
                 Dosyaları buraya sürükleyin veya tıklayın
@@ -345,7 +371,8 @@
 
 <div id="notif-overlay" class="position-fixed top-0 start-0 w-100 h-100 d-none" style="background: rgba(0, 0, 0, 0.2); z-index:900;"></div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 const username = (localStorage.getItem('username') || '').toLowerCase();
 if (!username) {
@@ -453,8 +480,10 @@ let shareExpiry = '';
 let currentFiles = [];
 let notifications = [];
 let activities = [];
+let diskChart;
 
 const sections = {
+    dashboard: document.getElementById('dashboard'),
     upload: document.getElementById('upload'),
     files: document.getElementById('files'),
     incoming: document.getElementById('incoming'),
@@ -716,6 +745,8 @@ function showSection(id) {
             loadPending();
         } else if (id === 'activities') {
             loadActivities();
+        } else if (id === 'dashboard') {
+            loadDashboard();
         }
     }
 }
@@ -1302,6 +1333,50 @@ function formatSize(bytes) {
     return size.toFixed(1) + ' ' + units[unit];
 }
 
+async function loadDashboard() {
+    const data = new FormData();
+    data.append('username', username);
+    const res = await fetch('/dashboard/data', { method: 'POST', body: data });
+    const json = await res.json();
+
+    const ctx = document.getElementById('disk-chart');
+    const labels = json.disk_usage.files.map(f => f.name);
+    const sizes = json.disk_usage.files.map(f => f.size);
+    if (diskChart) {
+        diskChart.destroy();
+    }
+    diskChart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+            labels,
+            datasets: [{ data: sizes }]
+        },
+        options: {
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    });
+    document.getElementById('disk-total').textContent = formatSize(json.disk_usage.total);
+    document.getElementById('top-file').textContent = json.downloads.top_file || '-';
+    document.getElementById('top-country').textContent = json.downloads.top_country || '-';
+    const teamList = document.getElementById('dashboard-teams');
+    teamList.innerHTML = '';
+    json.teams.forEach(t => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = `${t.name} - ${t.member_count} üye, ${t.file_count} dosya`;
+        teamList.appendChild(li);
+    });
+    const tbody = document.querySelector('#expiring-table tbody');
+    tbody.innerHTML = '';
+    json.expiring_files.forEach(f => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${f.filename}</td><td>${f.days_left}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
 async function viewTeam(teamId) {
     const data = new FormData();
     data.append('username', username);
@@ -1473,7 +1548,7 @@ if (initialHash.startsWith('team-')) {
     const teamId = initialHash.substring(5);
     viewTeam(teamId);
 } else {
-    const initialSection = initialHash || 'upload';
+    const initialSection = initialHash || 'dashboard';
     showSection(initialSection);
 }
 


### PR DESCRIPTION
## Summary
- provide `/dashboard/data` endpoint returning disk usage, download trends, team info and expiring files
- integrate a new dashboard view with Chart.js pie chart, download and team summaries, and expiring file list

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1ea1de64832b99c2efd8852a7bbc