### PR TITLE
Use public domain for share links and one-time approval tokens

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -42,6 +42,16 @@ def add_missing_columns():
                     "ALTER TABLE share_links ADD COLUMN rejected BOOLEAN DEFAULT FALSE"
                 )
             )
+    if "approve_token" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN approve_token VARCHAR")
+            )
+    if "reject_token" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN reject_token VARCHAR")
+            )
 
     member_cols = [col["name"] for col in inspector.get_columns("team_members")]
     if "accepted" not in member_cols:

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,8 @@ class ShareLink(Base):
     __tablename__ = "share_links"
 
     token = Column(String, primary_key=True, index=True)
+    approve_token = Column(String, unique=True, index=True, nullable=True)
+    reject_token = Column(String, unique=True, index=True, nullable=True)
     username = Column(String, index=True)
     filename = Column(String)
     expires_at = Column(DateTime)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -955,7 +955,7 @@ function renderFiles() {
                 linkIcon.classList.add('bi-hourglass-split');
             }
             linkBtn.addEventListener('click', async () => {
-                const url = window.location.origin + file.link;
+                const url = file.link;
                 try {
                     await navigator.clipboard.writeText(url);
                 } catch (e) {
@@ -1195,14 +1195,14 @@ async function loadPending() {
         approveBtn.className = 'btn btn-sm btn-success me-2';
         approveBtn.textContent = 'Onayla';
         approveBtn.addEventListener('click', async () => {
-            await fetch(`/share/approve/${item.token}`);
+            await fetch(`/share/approve/${item.approve_token}`);
             loadPending();
         });
         const rejectBtn = document.createElement('button');
         rejectBtn.className = 'btn btn-sm btn-danger';
         rejectBtn.textContent = 'Reddet';
         rejectBtn.addEventListener('click', async () => {
-            await fetch(`/share/reject/${item.token}`);
+            await fetch(`/share/reject/${item.reject_token}`);
             loadPending();
         });
         actTd.appendChild(approveBtn);


### PR DESCRIPTION
## Summary
- Make public base URL configurable for generated share links
- Generate separate approval and rejection tokens for file shares and invalidate on first use
- Update frontend to copy full public links and consume new tokens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2fc4c5e4832b94f4851c64936015