### PR TITLE
Allow share approval and rejection routes in nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,6 +61,22 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location ^~ /share/approve/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ^~ /share/reject/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             return 403;
         }


### PR DESCRIPTION
## Summary
- permit `/share/approve/` and `/share/reject/` paths in nginx and proxy them to the backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b360ae248832ba8897a76b7504897