### PR TITLE
Ensure file column alignment on secondary tables

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -43,8 +43,8 @@
     .table tbody tr:nth-child(even) {
         background-color: #f2f2f2 !important;
     }
-    .table th:first-child,
-    .table td:first-child {
+    #file-table th:first-child,
+    #file-table td:first-child {
         width: 1%;
         white-space: nowrap;
         text-align: center;


### PR DESCRIPTION
## Summary
- Prevent global first-column styling from centering file names in secondary tables
- Limit narrow, centered first-column styling to main file table only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b4a2ea524832b92f2a75e2f297bbc