### PR TITLE
Exclude trash directory from admin listing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -874,6 +874,9 @@ def list_files():
 
     files = []
     for user in os.listdir(DATA_DIR):
+        # Skip the special trash directory to avoid showing deleted files
+        if user == "_trash":
+            continue
         user_dir = os.path.join(DATA_DIR, user)
         if not os.path.isdir(user_dir):
             continue


### PR DESCRIPTION
## Summary
- ignore `_trash` directory when building admin file list so deleted items remain hidden

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b514a02a8832bb2f8b94f6f8021a3