### PR TITLE
Add messaging for public file shares

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -99,4 +99,17 @@ class UserFile(Base):
     deleted_at = Column(DateTime)
 
 
+class FileMessage(Base):
+    __tablename__ = "file_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, index=True)
+    username = Column(String, index=True)
+    filename = Column(String, index=True)
+    sender = Column(String)
+    message = Column(String)
+    created_at = Column(DateTime, default=lambda: datetime.utcnow() + timedelta(hours=3))
+    read = Column(Boolean, default=False)
+
+
 Base.metadata.create_all(engine)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -393,8 +393,8 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body" id="preview-content"></div>
-    </div>
   </div>
+</div>
 </div>
 
 <div class="modal fade" id="downloadLogModal" tabindex="-1">
@@ -414,6 +414,20 @@
       </div>
   </div>
 </div>
+</div>
+
+<div class="modal fade" id="messageModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Mesajlar</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-group text-start" id="message-list"></ul>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="modal fade" id="deleteConfirmModal" tabindex="-1">
@@ -1035,6 +1049,17 @@ function renderFiles() {
             dlBtn.textContent = `${file.download_count} İndirme`;
             dlBtn.addEventListener('click', () => showDownloadLogs(file));
             titleTd.appendChild(dlBtn);
+            if (file.message_count && file.message_count > 0) {
+                const msgBtn = document.createElement('button');
+                msgBtn.className = 'btn btn-sm btn-outline-info ms-2 position-relative';
+                msgBtn.innerHTML = '<i class="bi bi-chat-dots"></i>';
+                const badge = document.createElement('span');
+                badge.className = 'position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger';
+                badge.textContent = file.message_count;
+                msgBtn.appendChild(badge);
+                msgBtn.addEventListener('click', () => showMessages(file));
+                titleTd.appendChild(msgBtn);
+            }
         }
         tr.appendChild(titleTd);
 
@@ -1123,6 +1148,32 @@ async function showDownloadLogs(file) {
     }
     const modal = new bootstrap.Modal(document.getElementById('downloadLogModal'));
     modal.show();
+}
+
+async function showMessages(file) {
+    const fd = new FormData();
+    fd.append('username', adminMode ? file.username : username);
+    fd.append('filename', file.title);
+    const res = await fetch('/messages/list', { method: 'POST', body: fd });
+    const json = await res.json();
+    const list = document.getElementById('message-list');
+    list.innerHTML = '';
+    if (json.messages.length === 0) {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = 'Mesaj yok';
+        list.appendChild(li);
+    } else {
+        json.messages.forEach(m => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item';
+            li.innerHTML = `<strong>${m.sender}</strong>: ${m.message}`;
+            list.appendChild(li);
+        });
+    }
+    const modal = new bootstrap.Modal(document.getElementById('messageModal'));
+    modal.show();
+    loadFiles();
 }
 
 async function loadIncoming() {

--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -26,9 +26,44 @@
         <h2>{{ filename }}</h2>
         <p>Paylaşan: {{ uploader }}</p>
         <p>Boyut: {{ size }}</p>
+        <p>Açıklama: {{ description }}</p>
         <p>Geçerlilik: {{ expires_at }}</p>
         <a class="btn btn-primary" href="{{ url_for('public_download_file', token=token) }}">Download</a>
+        <button class="btn btn-secondary ms-2" id="toggle-comment">Yorum Ekle</button>
+        <div id="comment-form" class="mt-3 d-none">
+            <div class="mb-2">
+                <input type="text" class="form-control" id="sender" placeholder="Gönderen">
+            </div>
+            <div class="mb-2">
+                <textarea class="form-control" id="message" rows="3" placeholder="Mesaj"></textarea>
+            </div>
+            <button class="btn btn-primary" id="send-message">Gönder</button>
+            <div id="msg-result" class="mt-2"></div>
+        </div>
     {% endif %}
 </div>
+<script>
+document.getElementById('toggle-comment').addEventListener('click', () => {
+    document.getElementById('comment-form').classList.toggle('d-none');
+});
+document.getElementById('send-message').addEventListener('click', async () => {
+    const sender = document.getElementById('sender').value;
+    const message = document.getElementById('message').value;
+    const fd = new FormData();
+    fd.append('sender', sender);
+    fd.append('message', message);
+    const resp = await fetch('{{ url_for("public_message", token=token) }}', { method: 'POST', body: fd });
+    const data = await resp.json();
+    const result = document.getElementById('msg-result');
+    if (data.success) {
+        result.className = 'text-success';
+        result.textContent = 'Gönderildi';
+        document.getElementById('comment-form').classList.add('d-none');
+    } else {
+        result.className = 'text-danger';
+        result.textContent = data.error || 'Hata';
+    }
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display file descriptions and allow visitors to send messages on public pages
- track and list messages per file with notifications
- show unread message counts with popup viewer in main app

## Testing
- `python -m py_compile backend/main.py backend/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2e54fafc832b87a64d5c1287589f