### PR TITLE
feat: persist message icon and allow deletion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1016,6 +1016,7 @@ def list_messages():
         )
         result = [
             {
+                "id": m.id,
                 "sender": m.sender,
                 "message": m.message,
                 "created_at": m.created_at.strftime("%d/%m/%Y %H:%M"),
@@ -1028,6 +1029,21 @@ def list_messages():
     finally:
         db.close()
     return jsonify(messages=result)
+
+
+@app.route("/messages/delete", methods=["POST"])
+def delete_message():
+    msg_id = request.form.get("id")
+    db = SessionLocal()
+    try:
+        msg = db.query(FileMessage).filter_by(id=msg_id).first()
+        if msg:
+            db.delete(msg)
+            db.commit()
+            return jsonify(success=True)
+        return jsonify(success=False, error="Mesaj bulunamadı"), 404
+    finally:
+        db.close()
 
 
 @app.route("/download/logs", methods=["POST"])

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1049,17 +1049,11 @@ function renderFiles() {
             dlBtn.textContent = `${file.download_count} İndirme`;
             dlBtn.addEventListener('click', () => showDownloadLogs(file));
             titleTd.appendChild(dlBtn);
-            if (file.message_count && file.message_count > 0) {
-                const msgBtn = document.createElement('button');
-                msgBtn.className = 'btn btn-sm btn-outline-info ms-2 position-relative';
-                msgBtn.innerHTML = '<i class="bi bi-chat-dots"></i>';
-                const badge = document.createElement('span');
-                badge.className = 'position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger';
-                badge.textContent = file.message_count;
-                msgBtn.appendChild(badge);
-                msgBtn.addEventListener('click', () => showMessages(file));
-                titleTd.appendChild(msgBtn);
-            }
+            const msgBtn = document.createElement('button');
+            msgBtn.className = 'btn btn-sm btn-outline-info ms-2 d-flex align-items-center';
+            msgBtn.innerHTML = `<i class="bi bi-chat-dots"></i><span class="ms-1">${file.message_count || 0}</span>`;
+            msgBtn.addEventListener('click', () => showMessages(file));
+            titleTd.appendChild(msgBtn);
         }
         tr.appendChild(titleTd);
 
@@ -1166,14 +1160,31 @@ async function showMessages(file) {
     } else {
         json.messages.forEach(m => {
             const li = document.createElement('li');
-            li.className = 'list-group-item';
-            li.innerHTML = `<strong>${m.sender}</strong>: ${m.message}`;
+            li.className = 'list-group-item d-flex justify-content-between align-items-center';
+            const msg = document.createElement('div');
+            msg.innerHTML = `<strong>${m.sender}</strong>: ${m.message}`;
+            li.appendChild(msg);
+            const delBtn = document.createElement('button');
+            delBtn.className = 'btn btn-sm btn-danger';
+            delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+            delBtn.addEventListener('click', () => deleteMessage(m.id, file));
+            li.appendChild(delBtn);
             list.appendChild(li);
         });
     }
     const modal = new bootstrap.Modal(document.getElementById('messageModal'));
     modal.show();
     loadFiles();
+}
+
+async function deleteMessage(id, file) {
+    const fd = new FormData();
+    fd.append('id', id);
+    const res = await fetch('/messages/delete', { method: 'POST', body: fd });
+    const json = await res.json();
+    if (json.success) {
+        showMessages(file);
+    }
 }
 
 async function loadIncoming() {

--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -57,8 +57,9 @@ document.getElementById('send-message').addEventListener('click', async () => {
     const result = document.getElementById('msg-result');
     if (data.success) {
         result.className = 'text-success';
-        result.textContent = 'Gönderildi';
-        document.getElementById('comment-form').classList.add('d-none');
+        result.textContent = 'Mesaj gönderildi';
+        document.getElementById('sender').value = '';
+        document.getElementById('message').value = '';
     } else {
         result.className = 'text-danger';
         result.textContent = data.error || 'Hata';


### PR DESCRIPTION
## Summary
- show message icon and count for every file
- add delete option for file messages
- display confirmation after public comments are sent

## Testing
- `python -m py_compile backend/main.py backend/models.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c3181903c832bbce4081789b8dd5e