### PR TITLE
Show message icon only when messages exist

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1049,11 +1049,13 @@ function renderFiles() {
             dlBtn.textContent = `${file.download_count} İndirme`;
             dlBtn.addEventListener('click', () => showDownloadLogs(file));
             titleTd.appendChild(dlBtn);
-            const msgBtn = document.createElement('button');
-            msgBtn.className = 'btn btn-sm btn-outline-info ms-2 d-flex align-items-center';
-            msgBtn.innerHTML = `<i class="bi bi-chat-dots"></i><span class="ms-1">${file.message_count || 0}</span>`;
-            msgBtn.addEventListener('click', () => showMessages(file));
-            titleTd.appendChild(msgBtn);
+            if (file.message_count > 0) {
+                const msgBtn = document.createElement('button');
+                msgBtn.className = 'btn btn-sm btn-outline-info ms-2 d-inline-flex align-items-center';
+                msgBtn.innerHTML = `<i class="bi bi-chat-dots"></i><span class="ms-1">${file.message_count}</span>`;
+                msgBtn.addEventListener('click', () => showMessages(file));
+                titleTd.appendChild(msgBtn);
+            }
         }
         tr.appendChild(titleTd);
 


### PR DESCRIPTION
## Summary
- Display message icon only when files have messages
- Keep message icon aligned with count on single line

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c334876f0832b941aee8643721a5f