### PR TITLE
fix: show unlimited expiration only for shared files

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1068,7 +1068,13 @@ function renderFiles() {
         tr.appendChild(addedTd);
 
         const expTd = document.createElement('td');
-        expTd.textContent = file.public_expires_in || file.expires_in || 'Süresiz';
+        let expText = '';
+        if (file.link) {
+            expText = file.public_expires_in || 'Süresiz';
+        } else if (file.expires_in) {
+            expText = file.expires_in;
+        }
+        expTd.textContent = expText;
         tr.appendChild(expTd);
 
         const extTd = document.createElement('td');


### PR DESCRIPTION
## Summary
- prevent default "Süresiz" label when no share exists
- only display "Süresiz" when a file's public link is set without expiry

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c3b26d40c832b85d5df5aae182479