### PR TITLE
Show file and download counts on dashboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1698,6 +1698,7 @@ def dashboard_data():
                 total_size += size
     files.sort(key=lambda f: f["size"], reverse=True)
     top_disk_files = files[:5]
+    file_count = len(files)
     db = SessionLocal()
     try:
         logs = db.query(DownloadLog).filter_by(username=username).all()
@@ -1713,6 +1714,7 @@ def dashboard_data():
         top_countries = sorted(
             counts_by_country.items(), key=lambda x: x[1], reverse=True
         )[:5]
+        download_count = len(logs)
 
         memberships = (
             db.query(TeamMember)
@@ -1773,6 +1775,8 @@ def dashboard_data():
 
     return jsonify(
         disk_usage={"total": total_size, "files": top_disk_files},
+        file_count=file_count,
+        download_count=download_count,
         downloads={
             "files": [{"filename": f, "count": c} for f, c in top_files],
             "countries": [{"country": c, "count": n} for c, n in top_countries],

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -121,6 +121,10 @@
 
           <section id="dashboard" class="mb-4">
             <h2>Dashboard</h2>
+            <div class="mb-3">
+              <span class="me-4"><strong>Toplam Dosya:</strong> <span id="dashboard-file-count"></span></span>
+              <span><strong>Toplam İndirme:</strong> <span id="dashboard-download-count"></span></span>
+            </div>
             <div class="row">
               <div class="col-md-4 mb-4">
                 <h3>Disk Kullanımı</h3>
@@ -1572,6 +1576,9 @@ async function loadDashboard() {
     data.append('username', username);
     const res = await fetch('/dashboard/data', { method: 'POST', body: data });
     const json = await res.json();
+
+    document.getElementById('dashboard-file-count').textContent = json.file_count;
+    document.getElementById('dashboard-download-count').textContent = json.download_count;
 
     const ctx = document.getElementById('disk-chart');
     const labels = json.disk_usage.files.map(f => f.name);


### PR DESCRIPTION
## Summary
- expose file and download totals from `/dashboard/data`
- display user file and download counts in dashboard

## Testing
- `python -m py_compile backend/main.py`
- `flake8 backend/main.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c44dab680832b987b388ceae3c9cb