### PR TITLE
Log manager responses to share approvals and rejections

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1299,6 +1299,11 @@ def approve_share(token):
             link.username,
             f"'{link.filename}' paylaşımı onaylandı",
         )
+        log_activity(
+            link.username,
+            f"{link.username} kullanıcısının '{link.filename}' paylaşımı bölüm amiri tarafından onaylandı",
+            "share_public_approve",
+        )
         return render_template("message.html", message="Paylaşım onaylandı")
     finally:
         db.close()
@@ -1319,6 +1324,11 @@ def reject_share(token):
         create_notification(
             link.username,
             f"'{link.filename}' paylaşımı reddedildi",
+        )
+        log_activity(
+            link.username,
+            f"{link.username} kullanıcısının '{link.filename}' paylaşımı bölüm amiri tarafından reddedildi",
+            "share_public_reject",
         )
         return render_template("message.html", message="Paylaşım reddedildi")
     finally:


### PR DESCRIPTION
## Summary
- log share approval events to the activity feed
- log share rejection events to the activity feed

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_689c568a8640832b848678b4ccc898f0