### PR TITLE
Enforce manager requirement on login with whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For public shares requiring manager approval, the backend sends an e-mail to the
 - `GRAPH_CLIENT_ID`
 - `GRAPH_CLIENT_SECRET`
 - `GRAPH_SENDER` for the account used to send mail
+- `WHITE_LIST` comma-separated usernames allowed to log in even if the Manager field is empty
 
 Additional configuration options and dependencies can be found in `backend/requirements.txt`.
 


### PR DESCRIPTION
## Summary
- block login when AD user lacks Manager and not whitelisted
- allow empty-manager users defined in WHITE_LIST env to sign in
- document WHITE_LIST configuration option

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c945fe238832bae011389bb27118c