### PR TITLE
Handle missing manager without default admin

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -327,8 +327,7 @@ def manager_name_endpoint():
         return jsonify(manager="")
     _, _, manager_name = get_manager_info(user)
     if not manager_name:
-        admin_user = next(iter(ADMIN_USERS), None)
-        manager_name = get_full_name(admin_user) if admin_user else ""
+        return jsonify(manager="")
     return jsonify(manager=manager_name)
 
 


### PR DESCRIPTION
## Summary
- Do not substitute admin name when a user lacks a manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cae39738c832b8867be6bbd38d851