### PR TITLE
Fix checkbox column expanding on refresh

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -665,7 +665,7 @@ function autoFitColumn(table, index) {
         const prevWhiteSpace = cell.style.whiteSpace;
         const prevWidth = cell.style.width;
         cell.style.whiteSpace = 'nowrap';
-        cell.style.width = 'auto';
+        cell.style.width = '';
         const width = cell.scrollWidth;
         cell.style.whiteSpace = prevWhiteSpace;
         cell.style.width = prevWidth;


### PR DESCRIPTION
## Summary
- ensure autoFitColumn resets width before measuring to avoid checkbox column growth during refresh

## Testing
- `cd /workspace/ad-file-share/backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbd826124832bac4c9759fefdef94