### PR TITLE
Include usage purpose in share approval workflow

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -52,6 +52,9 @@ def add_missing_columns():
             conn.execute(
                 text("ALTER TABLE share_links ADD COLUMN reject_token VARCHAR")
             )
+    if "purpose" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE share_links ADD COLUMN purpose VARCHAR"))
 
     member_cols = [col["name"] for col in inspector.get_columns("team_members")]
     if "accepted" not in member_cols:

--- a/backend/models.py
+++ b/backend/models.py
@@ -15,6 +15,7 @@ class ShareLink(Base):
     expires_at = Column(DateTime)
     approved = Column(Boolean, default=False)
     rejected = Column(Boolean, default=False)
+    purpose = Column(String, default="")
 
 
 class DownloadLog(Base):

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -265,6 +265,7 @@
                         <th>Dosya</th>
                         <th>Gönderen</th>
                         <th>Geçerlilik</th>
+                        <th>Kullanım Amacı</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -371,6 +372,8 @@
           <option value="60">60 gün</option>
           <option value="0">Süresiz</option>
         </select>
+        <label class="form-label mt-3">Kullanım Amacı</label>
+        <input type="text" id="share-purpose" class="form-control">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="share-confirm">Paylaş</button>
@@ -1428,6 +1431,9 @@ async function loadPending() {
         const expTd = document.createElement('td');
         expTd.textContent = item.expires_at || 'Süresiz';
         tr.appendChild(expTd);
+        const purposeTd = document.createElement('td');
+        purposeTd.textContent = item.purpose || '';
+        tr.appendChild(purposeTd);
         const actTd = document.createElement('td');
         const approveBtn = document.createElement('button');
         approveBtn.className = 'btn btn-sm btn-success me-2';
@@ -1581,10 +1587,12 @@ publicShareBtn.addEventListener('click', () => {
 
 document.getElementById('share-confirm').addEventListener('click', async () => {
     const days = document.getElementById('share-expiry').value;
+    const purpose = document.getElementById('share-purpose').value;
     const formData = new FormData();
     formData.append('username', username);
     formData.append('filename', shareFileName);
     formData.append('days', days);
+    formData.append('purpose', purpose);
     await fetch('/share', { method: 'POST', body: formData });
     bootstrap.Modal.getInstance(document.getElementById('shareLinkModal')).hide();
     await loadFiles();


### PR DESCRIPTION
## Summary
- capture usage purpose when sharing files and store in ShareLink
- include purpose in approval emails and pending approvals table

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc43fb3b0832b8258102b3f46c9dd