### PR TITLE
Require usage purpose for public share

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1296,7 +1296,9 @@ def share_file():
     if not os.path.exists(file_path):
         return jsonify(success=False, error="Dosya bulunamadı")
     days = request.form.get("days")
-    purpose = request.form.get("purpose", "")
+    purpose = request.form.get("purpose", "").strip()
+    if not purpose:
+        return jsonify(success=False, error="Kullanım amacı gerekli")
     token = find_share_token(username, filename)
     if token is None:
         token = secrets.token_urlsafe(16)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -373,7 +373,7 @@
           <option value="0">Süresiz</option>
         </select>
         <label class="form-label mt-3">Kullanım Amacı</label>
-        <input type="text" id="share-purpose" class="form-control">
+        <input type="text" id="share-purpose" class="form-control" required>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="share-confirm">Paylaş</button>
@@ -1587,7 +1587,12 @@ publicShareBtn.addEventListener('click', () => {
 
 document.getElementById('share-confirm').addEventListener('click', async () => {
     const days = document.getElementById('share-expiry').value;
-    const purpose = document.getElementById('share-purpose').value;
+    const purposeInput = document.getElementById('share-purpose');
+    const purpose = purposeInput.value.trim();
+    if (!purpose) {
+        purposeInput.reportValidity();
+        return;
+    }
     const formData = new FormData();
     formData.append('username', username);
     formData.append('filename', shareFileName);


### PR DESCRIPTION
## Summary
- Make usage purpose field mandatory when creating a public share
- Validate usage purpose on server side

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc70ff448832ba4e18c8066648b5d