### PR TITLE
Allow deleting and downloading incoming user shares

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -85,6 +85,11 @@ def add_missing_columns():
         with engine.begin() as conn:
             conn.execute(text("ALTER TABLE user_files ADD COLUMN deleted_at TIMESTAMP"))
 
+    usershare_cols = [col["name"] for col in inspector.get_columns("user_shares")]
+    if "deleted_at" not in usershare_cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE user_shares ADD COLUMN deleted_at TIMESTAMP"))
+
     activity_cols = [col["name"] for col in inspector.get_columns("activities")]
     if "category" not in activity_cols:
         with engine.begin() as conn:

--- a/backend/models.py
+++ b/backend/models.py
@@ -87,6 +87,7 @@ class UserShare(Base):
     recipient = Column(String, index=True)
     filename = Column(String)
     expires_at = Column(DateTime)
+    deleted_at = Column(DateTime)
 
 
 class UserFile(Base):

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -218,6 +218,7 @@
                         <th>Dosya</th>
                         <th>Gönderen</th>
                         <th>Geçerlilik</th>
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody></tbody>
@@ -1281,14 +1282,36 @@ async function loadIncoming() {
     json.files.forEach(file => {
         const tr = document.createElement('tr');
         const nameTd = document.createElement('td');
-        nameTd.textContent = file.filename;
+        const dl = document.createElement('a');
+        dl.href = `/files/download?username=${encodeURIComponent(file.sender_id)}&filename=${encodeURIComponent(file.filename)}`;
+        dl.textContent = file.filename;
+        nameTd.appendChild(dl);
         tr.appendChild(nameTd);
         const senderTd = document.createElement('td');
         senderTd.textContent = file.sender;
         tr.appendChild(senderTd);
-       const expTd = document.createElement('td');
+        const expTd = document.createElement('td');
         expTd.textContent = file.expires_at || 'Süresiz';
         tr.appendChild(expTd);
+        const actTd = document.createElement('td');
+        const dlBtn = document.createElement('a');
+        dlBtn.href = `/files/download?username=${encodeURIComponent(file.sender_id)}&filename=${encodeURIComponent(file.filename)}`;
+        dlBtn.className = 'btn btn-sm btn-secondary me-2';
+        dlBtn.innerHTML = '<i class="bi bi-download"></i>';
+        actTd.appendChild(dlBtn);
+        const delBtn = document.createElement('button');
+        delBtn.className = 'btn btn-sm btn-danger';
+        delBtn.textContent = 'Sil';
+        delBtn.addEventListener('click', async () => {
+            const data = new FormData();
+            data.append('username', username);
+            data.append('sender', file.sender_id);
+            data.append('filename', file.filename);
+            await fetch('/incoming/delete', { method: 'POST', body: data });
+            loadIncoming();
+        });
+        actTd.appendChild(delBtn);
+        tr.appendChild(actTd);
         tbody.appendChild(tr);
     });
 }


### PR DESCRIPTION
## Summary
- Track per-recipient deletion on user shares
- Let users download or remove incoming shared files without affecting the sender
- Add DB migration and frontend controls for managing incoming shares

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_689dfbff5948832b9ef0342bf85b8835