### PR TITLE
Add optional max download limit for shared links

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -55,6 +55,18 @@ def add_missing_columns():
     if "purpose" not in share_cols:
         with engine.begin() as conn:
             conn.execute(text("ALTER TABLE share_links ADD COLUMN purpose VARCHAR"))
+    if "max_downloads" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN max_downloads INTEGER")
+            )
+    if "download_count" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE share_links ADD COLUMN download_count INTEGER DEFAULT 0"
+                )
+            )
 
     member_cols = [col["name"] for col in inspector.get_columns("team_members")]
     if "accepted" not in member_cols:
@@ -75,6 +87,11 @@ def add_missing_columns():
         with engine.begin() as conn:
             conn.execute(
                 text("ALTER TABLE download_logs ADD COLUMN country VARCHAR")
+            )
+    if "token" not in download_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE download_logs ADD COLUMN token VARCHAR")
             )
 
     userfile_cols = [col["name"] for col in inspector.get_columns("user_files")]

--- a/backend/models.py
+++ b/backend/models.py
@@ -16,6 +16,8 @@ class ShareLink(Base):
     approved = Column(Boolean, default=False)
     rejected = Column(Boolean, default=False)
     purpose = Column(String, default="")
+    max_downloads = Column(Integer, nullable=True)
+    download_count = Column(Integer, default=0)
 
 
 class DownloadLog(Base):
@@ -27,6 +29,7 @@ class DownloadLog(Base):
     timestamp = Column(DateTime, default=datetime.utcnow)
     ip_address = Column(String)
     country = Column(String)
+    token = Column(String, index=True, nullable=True)
 
 
 class Team(Base):

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -378,11 +378,13 @@
         </select>
         <label class="form-label mt-3">Kullanım Amacı</label>
         <input type="text" id="share-purpose" class="form-control" required>
+        <label class="form-label mt-3">Maksimum İndirme Sayısı</label>
+        <input type="number" id="share-max-downloads" class="form-control" min="1" placeholder="Opsiyonel">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="share-confirm">Paylaş</button>
       </div>
-</div>
+    </div>
 </div>
 </div>
 
@@ -1607,6 +1609,7 @@ publicShareBtn.addEventListener('click', () => {
         } else {
             msgAlert.classList.add('d-none');
         }
+        document.getElementById('share-max-downloads').value = '';
         modal.show();
     }
 });
@@ -1619,11 +1622,15 @@ document.getElementById('share-confirm').addEventListener('click', async () => {
         purposeInput.reportValidity();
         return;
     }
+    const maxDownloads = document.getElementById('share-max-downloads').value;
     const formData = new FormData();
     formData.append('username', username);
     formData.append('filename', shareFileName);
     formData.append('days', days);
     formData.append('purpose', purpose);
+    if (maxDownloads) {
+        formData.append('max_downloads', maxDownloads);
+    }
     await fetch('/share', { method: 'POST', body: formData });
     bootstrap.Modal.getInstance(document.getElementById('shareLinkModal')).hide();
     await loadFiles();


### PR DESCRIPTION
## Summary
- allow setting a maximum download count for shared links
- include allowed download count in approval emails and track per-link downloads
- expose optional "Maksimum İndirme Sayısı" field in share dialog

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e0004adb8832b933d0439fd37fa7d