### PR TITLE
Show remaining downloads for shared files

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -876,6 +876,8 @@ def list_files():
                     "expires_at": l.expires_at,
                     "approved": l.approved,
                     "rejected": l.rejected,
+                    "max_downloads": l.max_downloads,
+                    "download_count": l.download_count or 0,
                 }
                 for l in db.query(ShareLink)
                 .filter_by(username=username)
@@ -914,6 +916,11 @@ def list_files():
             link_exp = link_info.get("expires_at")
             approved = link_info.get("approved", False)
             rejected = link_info.get("rejected", False)
+            max_dl = link_info.get("max_downloads")
+            link_dl_count = link_info.get("download_count", 0)
+            remaining_dl = (
+                max(max_dl - link_dl_count, 0) if max_dl is not None else None
+            )
             mgr_name = manager_name if token and not approved else ""
             files.append(
                 {
@@ -938,6 +945,8 @@ def list_files():
                     "manager_name": mgr_name,
                     "download_count": counts.get(filename, 0),
                     "message_count": msg_counts.get(filename, 0),
+                    "max_downloads": max_dl,
+                    "remaining_downloads": remaining_dl,
                 }
             )
         files.sort(key=lambda f: f["added"], reverse=True)
@@ -958,6 +967,8 @@ def list_files():
                 "expires_at": l.expires_at,
                 "approved": l.approved,
                 "rejected": l.rejected,
+                "max_downloads": l.max_downloads,
+                "download_count": l.download_count or 0,
             }
             for l in db.query(ShareLink)
             .filter(ShareLink.rejected == False)
@@ -1009,6 +1020,11 @@ def list_files():
             link_exp = link_info.get("expires_at")
             approved = link_info.get("approved", False)
             rejected = link_info.get("rejected", False)
+            max_dl = link_info.get("max_downloads")
+            link_dl_count = link_info.get("download_count", 0)
+            remaining_dl = (
+                max(max_dl - link_dl_count, 0) if max_dl is not None else None
+            )
             mgr_name = manager_name if token and not approved else ""
             files.append(
                 {
@@ -1034,6 +1050,8 @@ def list_files():
                     "manager_name": mgr_name,
                     "download_count": counts.get((user, filename), 0),
                     "message_count": msg_counts.get((user, filename), 0),
+                    "max_downloads": max_dl,
+                    "remaining_downloads": remaining_dl,
                 }
             )
     files.sort(key=lambda f: f["added"], reverse=True)

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -1017,6 +1017,7 @@ function renderFiles() {
             f.public_expires_at,
             f.expires_in,
             f.public_expires_in,
+            f.remaining_downloads,
             f.extension,
             f.description,
             f.size,
@@ -1146,6 +1147,10 @@ function renderFiles() {
         let expText = '';
         if (file.link) {
             expText = file.public_expires_in || 'Süresiz';
+            if (file.max_downloads != null) {
+                const remaining = file.remaining_downloads ?? 0;
+                expText += `, ${remaining} indirme`;
+            }
         } else if (file.expires_in) {
             expText = file.expires_in;
         }


### PR DESCRIPTION
## Summary
- include max and remaining download counts when listing shared files
- display remaining download allowance in validity column when applicable

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e03cbdccc832b9527943dda7775b7