### PR TITLE
Add Zorunlu placeholder for share purpose field

### DIFF
--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -377,7 +377,7 @@
           <option value="0">Süresiz</option>
         </select>
         <label class="form-label mt-3">Kullanım Amacı</label>
-        <input type="text" id="share-purpose" class="form-control" required>
+        <input type="text" id="share-purpose" class="form-control" placeholder="Zorunlu" required>
         <label class="form-label mt-3">Maksimum İndirme Sayısı</label>
         <input type="number" id="share-max-downloads" class="form-control" min="1" placeholder="Opsiyonel">
       </div>


### PR DESCRIPTION
## Summary
- make share purpose input show a Zorunlu placeholder to indicate it is required

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0811e668832b86088b2ac0ea733a