### PR TITLE
Fix file list sort by added date

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -950,12 +950,14 @@ def list_files():
                 max(max_dl - link_dl_count, 0) if max_dl is not None else None
             )
             mgr_name = manager_name if token and not approved else ""
+            added_ts = stat.st_mtime
             files.append(
                 {
                     "title": filename,
-                    "added": datetime.fromtimestamp(stat.st_mtime).strftime(
+                    "added": datetime.fromtimestamp(added_ts).strftime(
                         "%d/%m/%Y %H:%M:%S"
                     ),
+                    "added_ts": added_ts,
                     "extension": os.path.splitext(filename)[1].lstrip("."),
                     "description": desc,
                     "size": stat.st_size,
@@ -977,7 +979,7 @@ def list_files():
                     "remaining_downloads": remaining_dl,
                 }
             )
-        files.sort(key=lambda f: f["added"], reverse=True)
+        files.sort(key=lambda f: f["added_ts"], reverse=True)
         return jsonify(files=files)
 
     db = SessionLocal()
@@ -1054,13 +1056,15 @@ def list_files():
                 max(max_dl - link_dl_count, 0) if max_dl is not None else None
             )
             mgr_name = manager_name if token and not approved else ""
+            added_ts = stat.st_mtime
             files.append(
                 {
                     "title": filename,
                     "username": user,
-                    "added": datetime.fromtimestamp(stat.st_mtime).strftime(
+                    "added": datetime.fromtimestamp(added_ts).strftime(
                         "%d/%m/%Y %H:%M:%S"
                     ),
+                    "added_ts": added_ts,
                     "extension": os.path.splitext(filename)[1].lstrip("."),
                     "description": desc,
                     "size": stat.st_size,
@@ -1082,7 +1086,7 @@ def list_files():
                     "remaining_downloads": remaining_dl,
                 }
             )
-    files.sort(key=lambda f: f["added"], reverse=True)
+    files.sort(key=lambda f: f["added_ts"], reverse=True)
     return jsonify(files=files)
 
 

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -577,7 +577,7 @@ window.addEventListener('beforeunload', () => {
         localStorage.setItem(SECTION_KEY, hash);
     }
 });
-let currentSort = { field: null, dir: 1 };
+let currentSort = { field: 'added', dir: -1 };
 
 function updateSortIcons() {
     document.querySelectorAll('#file-table thead th[data-field] .sort-icon').forEach(icon => {
@@ -1034,11 +1034,14 @@ function renderFiles() {
             } else if (currentSort.field === 'title') {
                 av = adminMode ? `${a.username} - ${a.title}` : a.title;
                 bv = adminMode ? `${b.username} - ${b.title}` : b.title;
+            } else if (currentSort.field === 'added') {
+                av = a.added_ts;
+                bv = b.added_ts;
             } else {
                 av = a[currentSort.field] || '';
                 bv = b[currentSort.field] || '';
             }
-            if (currentSort.field === 'size') {
+            if (currentSort.field === 'size' || currentSort.field === 'added') {
                 av = Number(av);
                 bv = Number(bv);
             } else {


### PR DESCRIPTION
## Summary
- sort backend file listings using timestamps
- default to newest files first in the UI
- compare added dates numerically when sorting in the frontend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b9ce647c832bb972197f95319595