### PR TITLE
Add modal for uploading document versions

### DIFF
--- a/backend/templates/document_detail.html
+++ b/backend/templates/document_detail.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <title>Document Detail</title>
+</head>
+<body>
+  <div class="container py-3">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h1 class="h3 mb-0">Document Detail</h1>
+      <div class="btn-toolbar">
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#versionModal">
+          Add Version
+        </button>
+      </div>
+    </div>
+
+    <h2 class="h5">Revision History</h2>
+    <ul id="revision-history" class="list-group mb-3">
+      <!-- Versions will be loaded here -->
+    </ul>
+  </div>
+
+  <!-- Modal -->
+  <div class="modal fade" id="versionModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <form id="version-form" class="modal-content" enctype="multipart/form-data">
+        <div class="modal-header">
+          <h5 class="modal-title">Upload New Version</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="version-file" class="form-label">File</label>
+            <input type="file" class="form-control" id="version-file" name="file" required />
+          </div>
+          <div class="mb-3">
+            <label for="version-note" class="form-label">Note</label>
+            <textarea class="form-control" id="version-note" name="note"></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Upload</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const docId = {{ doc_id | tojson }};
+
+    async function loadRevisions() {
+      const res = await fetch(`/api/documents/${docId}/versions`);
+      if (!res.ok) {
+        return;
+      }
+      const data = await res.json();
+      const list = document.getElementById('revision-history');
+      list.innerHTML = '';
+      (data.versions || []).forEach(v => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = v.name || v.id || '';
+        list.appendChild(li);
+      });
+    }
+
+    document.getElementById('version-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const form = e.target;
+      const formData = new FormData(form);
+      const res = await fetch(`/api/documents/${docId}/versions`, {
+        method: 'POST',
+        body: formData
+      });
+      if (res.ok) {
+        const modalEl = document.getElementById('versionModal');
+        const modal = bootstrap.Modal.getInstance(modalEl);
+        modal.hide();
+        form.reset();
+        await loadRevisions();
+      }
+    });
+
+    document.addEventListener('DOMContentLoaded', loadRevisions);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add toolbar button on document detail page to open a modal
- allow uploading a new document version with optional note
- refresh revision history via JavaScript after successful upload

## Testing
- `pytest`
- `flake8` *(fails: command not found; installation failed due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dcce7e04832b99be8b635a5a23b0