### PR TITLE
feat: add document version upload

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,5 @@ requests
 python-docx
 openpyxl
 python-pptx
+minio
 


### PR DESCRIPTION
## Summary
- add MinIO config and dependency
- implement POST `/api/documents/<int:doc_id>/versions` to store document versions and return version info

## Testing
- `pip install minio` *(fails: Could not find a version that satisfies the requirement minio)*
- `python -m py_compile backend/main.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6dda252f0832ba6d8fc19c7fa2aee