### PR TITLE
feat: track document versions

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -104,6 +104,19 @@ class UserFile(Base):
     deleted_at = Column(DateTime)
 
 
+class DocumentVersion(Base):
+    __tablename__ = "document_versions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    document_id = Column(Integer, ForeignKey("user_files.id"), index=True)
+    version = Column(String, index=True)
+    path = Column(String)
+    size = Column(Integer)
+    content_type = Column(String)
+    note = Column(String, default="")
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
 class FileMessage(Base):
     __tablename__ = "file_messages"
 


### PR DESCRIPTION
## Summary
- add DocumentVersion model to store metadata for file versions
- provide helper to compute next auto version number
- save DocumentVersion entry when uploading a new document version

## Testing
- `python -m py_compile backend/models.py backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ded3e318832b98f87b91ccc9a521