### PR TITLE
Log document version uploads

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -115,3 +115,6 @@ def add_missing_columns():
                     "ALTER TABLE activities ADD COLUMN category VARCHAR DEFAULT 'general'"
                 )
             )
+    if "details" not in activity_cols:
+        with engine.begin() as conn:
+            conn.execute(text("ALTER TABLE activities ADD COLUMN details JSON"))

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, Boolean
+from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, Boolean, JSON
 
 from database import Base, engine
 
@@ -79,6 +79,7 @@ class Activity(Base):
     username = Column(String, index=True)
     message = Column(String)
     category = Column(String, index=True, default="general")
+    details = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.utcnow() + timedelta(hours=3))
 
 


### PR DESCRIPTION
## Summary
- extend Activity model with JSON details
- add optional details parameter to `log_activity`
- record activity when uploading new document versions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e02dae20832b968dc9bcee05bcda