### PR TITLE
Add UserFile status and version tracking services

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -101,6 +101,16 @@ def add_missing_columns():
     if "deleted_at" not in userfile_cols:
         with engine.begin() as conn:
             conn.execute(text("ALTER TABLE user_files ADD COLUMN deleted_at TIMESTAMP"))
+    if "status" not in userfile_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE user_files ADD COLUMN status VARCHAR DEFAULT 'draft'")
+            )
+    if "active_version_id" not in userfile_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE user_files ADD COLUMN active_version_id INTEGER")
+            )
 
     usershare_cols = [col["name"] for col in inspector.get_columns("user_shares")]
     if "deleted_at" not in usershare_cols:
@@ -118,3 +128,10 @@ def add_missing_columns():
     if "details" not in activity_cols:
         with engine.begin() as conn:
             conn.execute(text("ALTER TABLE activities ADD COLUMN details JSON"))
+
+    version_cols = [col["name"] for col in inspector.get_columns("document_versions")]
+    if "is_active" not in version_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE document_versions ADD COLUMN is_active BOOLEAN DEFAULT FALSE")
+            )

--- a/backend/main.py
+++ b/backend/main.py
@@ -60,6 +60,7 @@ from models import (
     DocumentVersion,
 )
 from sqlalchemy import func
+from services import set_active_version
 
 load_dotenv()
 add_missing_columns()
@@ -2636,17 +2637,18 @@ def upload_document_version(doc_id):
             metadata={"note": note} if note else None,
         )
 
-        db.add(
-            DocumentVersion(
-                document_id=doc_id,
-                version=version_str,
-                path=object_name,
-                size=len(data),
-                content_type=file.mimetype,
-                note=note,
-            )
+        new_version = DocumentVersion(
+            document_id=doc_id,
+            version=version_str,
+            path=object_name,
+            size=len(data),
+            content_type=file.mimetype,
+            note=note,
         )
+        db.add(new_version)
         db.commit()
+        db.refresh(new_version)
+        set_active_version(db, new_version)
 
         log_activity(
             username_local,

--- a/backend/models.py
+++ b/backend/models.py
@@ -103,6 +103,8 @@ class UserFile(Base):
     expires_at = Column(DateTime)
     description = Column(String, default="")
     deleted_at = Column(DateTime)
+    status = Column(String, default="draft", index=True)
+    active_version_id = Column(Integer, ForeignKey("document_versions.id"), nullable=True)
 
 
 class DocumentVersion(Base):
@@ -116,6 +118,16 @@ class DocumentVersion(Base):
     content_type = Column(String)
     note = Column(String, default="")
     created_at = Column(DateTime, default=datetime.utcnow)
+    is_active = Column(Boolean, default=False)
+
+
+class UserFileStatusHistory(Base):
+    __tablename__ = "user_file_status_history"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_file_id = Column(Integer, ForeignKey("user_files.id"), index=True)
+    status = Column(String)
+    changed_at = Column(DateTime, default=datetime.utcnow)
 
 
 class FileMessage(Base):

--- a/backend/services.py
+++ b/backend/services.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import Union
+
+from sqlalchemy.orm import Session
+
+from models import UserFile, DocumentVersion, UserFileStatusHistory
+
+STATUS_DRAFT = "draft"
+STATUS_REVIEW = "review"
+STATUS_APPROVED = "approved"
+STATUS_PUBLISHED = "published"
+
+VALID_STATUSES = {
+    STATUS_DRAFT,
+    STATUS_REVIEW,
+    STATUS_APPROVED,
+    STATUS_PUBLISHED,
+}
+
+
+def change_userfile_status(db: Session, user_file_id: int, new_status: str) -> UserFile:
+    """Change the status of a UserFile and record the transition history."""
+    if new_status not in VALID_STATUSES:
+        raise ValueError("Invalid status")
+    user_file = db.query(UserFile).filter_by(id=user_file_id).first()
+    if not user_file:
+        raise ValueError("UserFile not found")
+
+    user_file.status = new_status
+    history = UserFileStatusHistory(
+        user_file_id=user_file_id, status=new_status, changed_at=datetime.utcnow()
+    )
+    db.add(history)
+    db.commit()
+    db.refresh(user_file)
+    return user_file
+
+
+def set_active_version(db: Session, version: Union[DocumentVersion, int]) -> DocumentVersion:
+    """Mark given DocumentVersion as active and update its parent UserFile."""
+    if isinstance(version, int):
+        version = db.query(DocumentVersion).filter_by(id=version).first()
+    if not version:
+        raise ValueError("DocumentVersion not found")
+
+    db.query(DocumentVersion).filter(
+        DocumentVersion.document_id == version.document_id
+    ).update({"is_active": False})
+    version.is_active = True
+
+    user_file = db.query(UserFile).filter_by(id=version.document_id).first()
+    if user_file:
+        user_file.active_version_id = version.id
+
+    db.commit()
+    db.refresh(version)
+    return version


### PR DESCRIPTION
## Summary
- add `status` and `active_version_id` fields to `UserFile`
- track active document versions and status history
- provide services for status transitions and active version updates

## Testing
- `python -m py_compile backend/models.py backend/database.py backend/main.py backend/services.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6e7041564832bb03fc0000dff2a95