### PR TITLE
docs: add Baylan Send Turkish user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ python desktop/file_box.py --user alice
 Dropping a file onto the window prompts for the recipient's username. The
 file is then copied into the recipient's box where it will appear in their
 own application window.
+
+## Kullanıcı dökümantasyonu
+
+Türkçe kullanıcı rehberi için `docs/BaylanSend_Kullanici_Talimatlari_Kullanim_Rehberi.md` dosyasına bakabilirsiniz.

--- a/docs/BaylanSend_Kullanici_Talimatlari_Kullanim_Rehberi.md
+++ b/docs/BaylanSend_Kullanici_Talimatlari_Kullanim_Rehberi.md
@@ -1,0 +1,153 @@
+# Baylan Send Kullanıcı Talimatları – Kullanım Rehberi
+
+Bu rehber, Baylan Send uygulamasını günlük kullanımda hızlı ve doğru şekilde kullanmanız için hazırlanmıştır.
+
+## 1) Uygulamanın amacı
+
+Baylan Send; kurum içi dosya yükleme, dosya paylaşma, bağlantı ile güvenli dış paylaşım, ekip bazlı paylaşım ve dosya aktivitelerini takip etme ihtiyaçları için kullanılır.
+
+## 2) Giriş yapma
+
+1. Uygulama giriş ekranında **Kullanıcı Adı** ve **Şifre** alanlarını doldurun.
+2. **Giriş** butonuna basın.
+3. Giriş başarılıysa ana ekrana yönlendirilirsiniz.
+
+> Not: Kullanıcı adı küçük harfe çevrilerek işlenir. Kullanıcı adı ve şifre boş bırakılamaz.
+
+## 3) Ana ekran menüleri
+
+Sol menüde aşağıdaki bölümler bulunur:
+
+- **Dashboard**: Toplam dosya, indirme ve kullanım özetleri.
+- **Yükle**: Yeni dosya yükleme alanı.
+- **Dosyalarım**
+  - **Gelen Dosyalar**
+  - **Giden Dosyalar**
+  - **Çöp Kutusu**
+  - (gerekirse) **Onay Bekleyenler**
+- **Ekipler**: Ekip görüntüleme ve ekip paylaşımları.
+- **Aktiviteler**: İşlem geçmişi.
+
+Üst alanda:
+- **Bildirim zili**: Onaylar, paylaşımlar ve uyarılar.
+- **Admin** (yetkili kullanıcılar için).
+- **Çıkış** butonu.
+
+## 4) Dosya yükleme
+
+1. **Yükle** bölümüne girin.
+2. Dosyayı sürükleyip bırakın veya alana tıklayıp seçin.
+3. Dosya listede göründüğünde **Yükle** butonuna basın.
+4. Sonucu ekran mesajından kontrol edin.
+
+## 5) Dosyalarım ekranında temel işlemler
+
+**Dosyalarım** listesinde bir veya daha fazla dosya seçtiğinizde aşağıdaki işlemler aktif olur:
+
+- **Sil**: Dosyayı çöp kutusuna taşır.
+- **Düzenle**: Açıklama / geçerlilik gibi alanları günceller.
+- **Kullanıcıya Gönder**: Kurum içi kullanıcıya dosya gönderir.
+- **Paylaş**: Dış bağlantı (public link) üretir.
+- **Gruba Ekle**: Seçili ekip(ler)e dosya ekler.
+
+Ek özellikler:
+- **Ara** kutusu ile listede filtreleme.
+- Sayfa başına kayıt sayısı (15 / 30 / 100).
+- Sütun bazlı sıralama ve tablo gezinimi.
+
+## 6) Gelen ve giden dosyalar
+
+### Gelen Dosyalar
+- Size gönderilen dosyaları listeler.
+- Dosyayı indirebilir, gerekli durumlarda kaydı kaldırabilirsiniz.
+
+### Giden Dosyalar
+- Başkalarına veya ekiplere gönderdiğiniz dosyaları gösterir.
+- Yanlış paylaşımları kaldırmak için ilgili kaydı silebilirsiniz.
+
+## 7) Çöp Kutusu
+
+- Silinen dosyalar geçici olarak burada tutulur.
+- Uygunsa geri alma (restore) yapılabilir.
+- **Çöpü Boşalt** ile kalıcı temizleme yapılır.
+
+> Önemli: Kalıcı silme sonrasında dosyayı geri getirmek mümkün olmayabilir.
+
+## 8) Dış bağlantı ile paylaşım (Public Share)
+
+1. **Dosyalarım** bölümünde dosyayı seçin.
+2. **Paylaş** butonuna basın.
+3. Kullanım amacı (purpose) girin.
+4. İsteğe bağlı:
+   - Bağlantı geçerlilik süresi (gün)
+   - Maksimum indirme sayısı
+5. Oluşan bağlantıyı ilgili kişiyle paylaşın.
+
+### Onay akışı
+- Bazı kullanıcılar için paylaşım doğrudan onaylanır.
+- Kurala bağlı durumlarda paylaşım **yönetici onayına** düşer.
+- Onay/reddetme sonucunda bildirim oluşur.
+
+### Dış kullanıcı ekranı
+Bağlantıyı açan kişi:
+- Dosya adı, boyutu, paylaşan kişi ve açıklama bilgilerini görür.
+- **Download** ile dosyayı indirir.
+- İsterse **Yorum Ekle** alanından mesaj gönderebilir.
+
+Bağlantı durumu uygunsuzsa bilgilendirme mesajı gösterilir:
+- Süresi dolmuş,
+- Reddedilmiş,
+- Onay bekliyor,
+- Maksimum indirme sayısına ulaşılmış,
+- Dosya sunucudan kaldırılmış.
+
+## 9) Ekipler
+
+Ekipler bölümünde genel olarak şu işlemler yapılır:
+- Ekip listesi görüntüleme,
+- Ekibe üye ekleme / çıkarma,
+- Daveti kabul etme / reddetme,
+- Ekip dosyası ekleme / silme,
+- Ekipten ayrılma (yetkiye göre).
+
+## 10) Dashboard ve aktiviteler
+
+### Dashboard
+- Toplam dosya sayısı,
+- Toplam indirme,
+- Disk kullanımı,
+- En çok indirilen dosyalar,
+- Ülke bazlı indirmeler,
+- Ekip özeti,
+- Süresi yaklaşan dosyalar.
+
+### Aktiviteler
+- Kullanıcı işlemleri kayıt altındadır.
+- Paylaşım, silme, onay vb. eylemler izlenebilir.
+
+## 11) Bildirimler
+
+Bildirim zili üzerinden:
+- Yeni bildirimleri görüntüleyebilir,
+- Okundu/temizleme/silme işlemleri yapabilirsiniz.
+
+Onay bekleyen paylaşım, ekip daveti ve dosya hareketleri burada görünür.
+
+## 12) Güvenli kullanım önerileri
+
+- Dosya paylaşmadan önce alıcıyı kontrol edin.
+- Public link için mutlaka anlamlı bir **kullanım amacı** yazın.
+- Gerekmedikçe uzun süreli veya sınırsız indirmeli link üretmeyin.
+- Hassas dosyalarda kısa geçerlilik süresi tercih edin.
+- Ortak bilgisayarlarda işiniz bitince **Çıkış** yapın.
+
+## 13) Sık karşılaşılan durumlar
+
+- **Giriş başarısız**: Kullanıcı adı/şifreyi ve domain bilgisini kontrol edin.
+- **Dosya bulunamadı**: Dosya silinmiş veya taşınmış olabilir.
+- **Bağlantı açılmıyor**: Link süresi dolmuş ya da onay bekliyor olabilir.
+- **Paylaşım görünmüyor**: Bildirimler ve Giden Dosyalar ekranını kontrol edin.
+
+## 14) Destek
+
+Uygulama erişim, yetki, AD hesabı veya paylaşım onayıyla ilgili sorunlarda kurum BT ekibiyle iletişime geçin.


### PR DESCRIPTION
### Motivation

- Provide a complete Turkish end-user guide so non-English users can learn how to use Baylan Send for uploads, sharing, approvals, teams and troubleshooting. 
- Improve discoverability by linking the guide from the project `README.md`.

### Description

- Added a new documentation file `docs/BaylanSend_Kullanici_Talimatlari_Kullanim_Rehberi.md` containing a step‑by‑step Turkish user guide. 
- Updated `README.md` to include a `## Kullanıcı dökümantasyonu` section that points to the new guide. 
- Changes were committed with the message `docs: add Baylan Send Turkish user guide`.

### Testing

- Ran `python -m compileall backend` to ensure Python sources in `backend` still compile, and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae84e1260832bbb4654f631826049)