### PR TITLE
Şifre korumalı fabrika dışı paylaşım desteği

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -84,6 +84,11 @@ def add_missing_columns():
                     "ALTER TABLE share_links ADD COLUMN download_count INTEGER DEFAULT 0"
                 )
             )
+    if "share_password_hash" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN share_password_hash VARCHAR")
+            )
 
     member_cols = [col["name"] for col in inspector.get_columns("team_members")]
     if "accepted" not in member_cols:

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ mimetypes.add_type("text/csv", ".csv")
 import msal
 import requests
 from functools import lru_cache
+from werkzeug.security import check_password_hash, generate_password_hash
 
 from flask import (
     Flask,
@@ -707,6 +708,7 @@ def create_share_link(
     reject_token: str | None = None,
     purpose: str = "",
     max_downloads: int | None = None,
+    share_password_hash: str | None = None,
 ):
     db = SessionLocal()
     try:
@@ -722,6 +724,7 @@ def create_share_link(
                 rejected=False,
                 purpose=purpose,
                 max_downloads=max_downloads,
+                share_password_hash=share_password_hash,
             )
         )
         db.commit()
@@ -737,6 +740,43 @@ def delete_share_link(username: str, filename: str):
     finally:
         db.close()
 
+
+
+
+def validate_public_link(token: str):
+    cleanup_expired_files()
+    db = SessionLocal()
+    try:
+        link = db.query(ShareLink).filter_by(token=token).first()
+        if link and link.expires_at and link.expires_at < datetime.utcnow():
+            db.delete(link)
+            db.commit()
+            return None, "Bağlantının süresi dolmuş."
+        if not link:
+            return None, "Bağlantının süresi dolmuş."
+        if link.rejected:
+            return None, "Bağlantı reddedildi."
+        if not link.approved:
+            return None, "Bağlantı onay bekliyor."
+        if link.max_downloads and link.download_count >= link.max_downloads:
+            db.delete(link)
+            db.commit()
+            return None, "Bağlantı için izin verilen maksimum indirme sayısına ulaşıldı."
+        return link, None
+    finally:
+        db.close()
+
+
+def public_link_requires_password(link: ShareLink) -> bool:
+    return bool(link and link.share_password_hash)
+
+
+def public_link_password_valid(link: ShareLink, password: str) -> bool:
+    if not public_link_requires_password(link):
+        return True
+    if not password:
+        return False
+    return check_password_hash(link.share_password_hash, password)
 
 def delete_share_notification(username: str, filename: str):
     mgr_user, _, _ = get_manager_info(username)
@@ -1835,6 +1875,7 @@ def share_file():
     days = request.form.get("days")
     purpose = request.form.get("purpose", "").strip()
     max_downloads = request.form.get("max_downloads")
+    share_password = request.form.get("share_password", "").strip()
     if not purpose:
         return jsonify(success=False, error="Kullanım amacı gerekli")
     token = find_share_token(username, filename)
@@ -1867,6 +1908,7 @@ def share_file():
             approve_token = secrets.token_urlsafe(16)
             reject_token = secrets.token_urlsafe(16)
         max_dl = int(max_downloads) if max_downloads and int(max_downloads) > 0 else None
+        share_password_hash = generate_password_hash(share_password) if share_password else None
         create_share_link(
             token,
             username,
@@ -1877,6 +1919,7 @@ def share_file():
             reject_token=reject_token,
             purpose=purpose,
             max_downloads=max_dl,
+            share_password_hash=share_password_hash,
         )
         log_activity(
             username,
@@ -2330,40 +2373,15 @@ def delete_outgoing():
 
 @app.route("/public/<token>", methods=["GET"])
 def public_page(token):
-    cleanup_expired_files()
-    db = SessionLocal()
-    try:
-        link = db.query(ShareLink).filter_by(token=token).first()
-        if link and link.expires_at and link.expires_at < datetime.utcnow():
-            db.delete(link)
-            db.commit()
-            link = None
-    finally:
-        db.close()
+    link, error = validate_public_link(token)
     if not link:
-        return render_template("public.html", error="Bağlantının süresi dolmuş.")
-    if link.rejected:
-        return render_template("public.html", error="Bağlantı reddedildi.")
-    if not link.approved:
-        return render_template("public.html", error="Bağlantı onay bekliyor.")
-    if link.max_downloads and link.download_count >= link.max_downloads:
-        db = SessionLocal()
-        try:
-            link_db = db.query(ShareLink).filter_by(token=token).first()
-            if link_db:
-                db.delete(link_db)
-                db.commit()
-        finally:
-            db.close()
-        return render_template(
-            "public.html", error="Bağlantı için izin verilen maksimum indirme sayısına ulaşıldı."
-        )
+        return render_template("public.html", error=error, token=token, password_protected=False)
     username = link.username
     filename = link.filename
     user_dir = os.path.join(DATA_DIR, username)
     file_path = os.path.join(user_dir, filename)
     if not os.path.exists(file_path):
-        return render_template("public.html", error="Dosya sunucudan kaldırılmıştır.")
+        return render_template("public.html", error="Dosya sunucudan kaldırılmıştır.", token=token, password_protected=False)
     size = format_file_size(os.path.getsize(file_path))
     uploader = get_full_name(username)
     db = SessionLocal()
@@ -2380,45 +2398,29 @@ def public_page(token):
         size=size,
         description=description,
         expires_at=link.expires_at.strftime("%d/%m/%Y") if link.expires_at else "",
+        password_protected=public_link_requires_password(link),
     )
 
 
-@app.route("/public/<token>/download", methods=["GET"])
+@app.route("/public/<token>/download", methods=["GET", "POST"])
+
 def public_download_file(token):
-    cleanup_expired_files()
-    db = SessionLocal()
-    try:
-        link = db.query(ShareLink).filter_by(token=token).first()
-        if link and link.expires_at and link.expires_at < datetime.utcnow():
-            db.delete(link)
-            db.commit()
-            link = None
-    finally:
-        db.close()
+    link, error = validate_public_link(token)
     if not link:
-        return render_template("public.html", error="Bağlantının süresi dolmuş.")
-    if link.rejected:
-        return render_template("public.html", error="Bağlantı reddedildi.")
-    if not link.approved:
-        return render_template("public.html", error="Bağlantı onay bekliyor.")
-    if link.max_downloads and link.download_count >= link.max_downloads:
-        db = SessionLocal()
-        try:
-            link_db = db.query(ShareLink).filter_by(token=token).first()
-            if link_db:
-                db.delete(link_db)
-                db.commit()
-        finally:
-            db.close()
-        return render_template(
-            "public.html", error="Bağlantı için izin verilen maksimum indirme sayısına ulaşıldı."
-        )
+        return render_template("public.html", error=error, token=token, password_protected=False)
     username = link.username
     filename = link.filename
     user_dir = os.path.join(DATA_DIR, username)
     file_path = os.path.join(user_dir, filename)
     if not os.path.exists(file_path):
-        return render_template("public.html", error="Dosya sunucudan kaldırılmıştır.")
+        return render_template("public.html", error="Dosya sunucudan kaldırılmıştır.", token=token, password_protected=False)
+    if request.method == "POST":
+        payload = request.get_json(silent=True) or {}
+        password = (payload.get("password") or "").strip()
+        if not public_link_password_valid(link, password):
+            return jsonify(success=False, error="Şifre hatalı"), 403
+    elif public_link_requires_password(link):
+        return render_template("public.html", error="İndirme için şifre doğrulaması gerekli.", token=token, password_protected=False)
     log_download(username, filename, session.get("username"), token)
     return send_file(file_path, as_attachment=True, download_name=filename)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,7 @@ class ShareLink(Base):
     purpose = Column(String, default="")
     max_downloads = Column(Integer, nullable=True)
     download_count = Column(Integer, default=0)
+    share_password_hash = Column(String, nullable=True)
 
 
 class DownloadLog(Base):

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -380,6 +380,8 @@
         <input type="text" id="share-purpose" class="form-control" placeholder="Zorunlu" required>
         <label class="form-label mt-3">Maksimum İndirme Sayısı</label>
         <input type="number" id="share-max-downloads" class="form-control" min="1" placeholder="Opsiyonel">
+        <label class="form-label mt-3">Paylaşım Şifresi</label>
+        <input type="password" id="share-password" class="form-control" placeholder="Opsiyonel">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="share-confirm">Paylaş</button>
@@ -1625,6 +1627,7 @@ publicShareBtn.addEventListener('click', () => {
             msgAlert.classList.add('d-none');
         }
         document.getElementById('share-max-downloads').value = '';
+        document.getElementById('share-password').value = '';
         modal.show();
     }
 });
@@ -1638,6 +1641,7 @@ document.getElementById('share-confirm').addEventListener('click', async () => {
         return;
     }
     const maxDownloads = document.getElementById('share-max-downloads').value;
+    const sharePassword = document.getElementById('share-password').value;
     const formData = new FormData();
     formData.append('username', username);
     formData.append('filename', shareFileName);
@@ -1645,6 +1649,9 @@ document.getElementById('share-confirm').addEventListener('click', async () => {
     formData.append('purpose', purpose);
     if (maxDownloads) {
         formData.append('max_downloads', maxDownloads);
+    }
+    if (sharePassword) {
+        formData.append('share_password', sharePassword);
     }
     await fetch('/share', { method: 'POST', body: formData });
     bootstrap.Modal.getInstance(document.getElementById('shareLinkModal')).hide();

--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -28,7 +28,10 @@
         <p>Boyut: {{ size }}</p>
         <p>Açıklama: {{ description }}</p>
         <p>Geçerlilik: {{ expires_at or 'Süresiz' }}</p>
-        <a class="btn btn-primary" href="{{ url_for('public_download_file', token=token) }}">Download</a>
+        {% if password_protected %}
+            <p class="text-warning"><i class="bi bi-shield-lock"></i> Bu paylaşım şifre ile korunmaktadır.</p>
+        {% endif %}
+        <a class="btn btn-primary" href="#" id="download-btn">Download</a>
         <button class="btn btn-secondary ms-2" id="toggle-comment">Yorum Ekle</button>
         <div id="comment-form" class="mt-3 d-none">
             <div class="mb-2">
@@ -42,11 +45,35 @@
         </div>
     {% endif %}
 </div>
+
+<div class="modal fade" id="passwordModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Şifre Doğrulama</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <input type="password" id="download-password" class="form-control" placeholder="Şifre">
+        <div id="password-error" class="text-danger mt-2"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="password-submit">İndir</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-document.getElementById('toggle-comment').addEventListener('click', () => {
+const downloadUrl = '{{ url_for("public_download_file", token=token) }}';
+const isPasswordProtected = {{ 'true' if password_protected else 'false' }};
+
+document.getElementById('toggle-comment')?.addEventListener('click', () => {
     document.getElementById('comment-form').classList.toggle('d-none');
 });
-document.getElementById('send-message').addEventListener('click', async () => {
+
+document.getElementById('send-message')?.addEventListener('click', async () => {
     const sender = document.getElementById('sender').value;
     const message = document.getElementById('message').value;
     const fd = new FormData();
@@ -64,6 +91,64 @@ document.getElementById('send-message').addEventListener('click', async () => {
         result.className = 'text-danger';
         result.textContent = data.error || 'Hata';
     }
+});
+
+function triggerDownloadFromBlob(blob, filename) {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename || '';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+}
+
+async function requestProtectedDownload(password) {
+    const response = await fetch(downloadUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password })
+    });
+
+    if (!response.ok) {
+        let errText = 'Şifre hatalı veya indirme başarısız';
+        try {
+            const json = await response.json();
+            errText = json.error || errText;
+        } catch (_) {}
+        throw new Error(errText);
+    }
+
+    const blob = await response.blob();
+    const contentDisposition = response.headers.get('Content-Disposition') || '';
+    const match = contentDisposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
+    const fileName = decodeURIComponent(match?.[1] || match?.[2] || 'download');
+    triggerDownloadFromBlob(blob, fileName);
+}
+
+document.getElementById('download-btn')?.addEventListener('click', async (event) => {
+    event.preventDefault();
+    if (!isPasswordProtected) {
+        window.location.href = downloadUrl;
+        return;
+    }
+    const modalEl = document.getElementById('passwordModal');
+    const modal = new bootstrap.Modal(modalEl);
+    document.getElementById('password-error').textContent = '';
+    document.getElementById('download-password').value = '';
+    modal.show();
+
+    const submitBtn = document.getElementById('password-submit');
+    submitBtn.onclick = async () => {
+        const password = document.getElementById('download-password').value;
+        try {
+            await requestProtectedDownload(password);
+            modal.hide();
+        } catch (err) {
+            document.getElementById('password-error').textContent = err.message;
+        }
+    };
 });
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Kullanıcıların fabrika dışına açtıkları paylaşımlar için isteğe bağlı şifre koruması eklenerek paylaşımların daha güvenli hale getirilmesi amaçlandı. 
- Mevcut veri tabanlarıyla uyumluluk sağlamak için geriye dönük kolon ekleme kontrolü eklendi.

### Description
- `ShareLink` modeline `share_password_hash` alanı eklendi ve `add_missing_columns()` içinde bu kolonun eksikse eklenmesi sağlandı. 
- `/share` endpoint'i `share_password` parametresini kabul edip `generate_password_hash()` ile hashleyerek `ShareLink` kaydına yazıyor. 
- Public link doğrulama ortaklaştırılarak `validate_public_link()` yardımcı fonksiyonu eklendi ve şifre gereksinimi/ doğrulaması için `public_link_requires_password()` ve `public_link_password_valid()` fonksiyonları eklendi. 
- `/public/<token>` sayfası artık render edilirken `password_protected` bilgisi sağlıyor ve `/public/<token>/download` endpoint'i `GET` ile normal akışı, `POST` ile JSON gövdesinden gelen şifreyle doğrulamayı destekleyecek şekilde güncellendi. 
- Ön uçta paylaşım modalına `Paylaşım Şifresi` alanı eklendi ve public indirme sayfasına Bootstrap modal ile şifre sorma/POST indirme akışı ile ilgili JavaScript eklendi.

### Testing
- Python dosyalarının derlenebilirliği için `python -m py_compile backend/main.py backend/database.py backend/models.py` çalıştırıldı ve başarılı oldu. 
- Lokal sqlite ile tablo/alan ekleme ve demo veri ekleyerek şifreli paylaşım kaydı oluşturma senaryosu başarıyla çalıştırıldı. 
- Geliştirme sunucusu `python backend/main.py` ile başlatıldı; public sayfa manuel test için erişilebilir durumda çalıştı; Playwright tabanlı ekran görüntüsü alma denemesi ise Chromium ortamında `SIGSEGV` nedeniyle başarısız oldu (ortam kısıtlaması kaynaklı).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b330c56c832badaa5914ac106073)