### PR TITLE
Add 'Kurum içi' internal-only share mode and enforce local-only public URLs

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -89,6 +89,11 @@ def add_missing_columns():
             conn.execute(
                 text("ALTER TABLE share_links ADD COLUMN share_password_hash VARCHAR")
             )
+    if "is_internal" not in share_cols:
+        with engine.begin() as conn:
+            conn.execute(
+                text("ALTER TABLE share_links ADD COLUMN is_internal BOOLEAN DEFAULT FALSE")
+            )
 
     member_cols = [col["name"] for col in inspector.get_columns("team_members")]
     if "accepted" not in member_cols:

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ import time
 import zipfile
 import ipaddress
 import html
+from urllib.parse import urlparse
 
 # Ensure previewed file types have proper MIME types
 mimetypes.add_type("image/png", ".png")
@@ -71,6 +72,8 @@ add_missing_columns()
 
 PUBLIC_BASE_URL = os.getenv("PUBLIC_BASE_URL", "https://sendv2.baylan.info.tr").rstrip("/")
 LOGIN_BASE_URL = os.getenv("LOGIN_BASE_URL", "https://send.baylan.local").rstrip("/")
+INTERNAL_BASE_URL = os.getenv("INTERNAL_BASE_URL", "https://send.baylan.local").rstrip("/")
+INTERNAL_HOST = (urlparse(INTERNAL_BASE_URL).hostname or "").lower()
 
 app = Flask(__name__)
 app.secret_key = os.getenv("FLASK_SECRET_KEY", "super-secret-key")
@@ -709,6 +712,7 @@ def create_share_link(
     purpose: str = "",
     max_downloads: int | None = None,
     share_password_hash: str | None = None,
+    is_internal: bool = False,
 ):
     db = SessionLocal()
     try:
@@ -725,6 +729,7 @@ def create_share_link(
                 purpose=purpose,
                 max_downloads=max_downloads,
                 share_password_hash=share_password_hash,
+                is_internal=is_internal,
             )
         )
         db.commit()
@@ -739,6 +744,16 @@ def delete_share_link(username: str, filename: str):
         db.commit()
     finally:
         db.close()
+
+
+def get_share_base_url(link: ShareLink | None = None, is_internal: bool = False) -> str:
+    if link is not None:
+        return INTERNAL_BASE_URL if bool(link.is_internal) else PUBLIC_BASE_URL
+    return INTERNAL_BASE_URL if is_internal else PUBLIC_BASE_URL
+
+
+def request_host() -> str:
+    return request.host.split(":")[0].strip().lower()
 
 
 
@@ -758,6 +773,8 @@ def validate_public_link(token: str):
             return None, "Bağlantı reddedildi."
         if not link.approved:
             return None, "Bağlantı onay bekliyor."
+        if bool(link.is_internal) and request_host() != INTERNAL_HOST:
+            return None, "Bu bağlantı yalnızca kurum içinden erişilebilir."
         if link.max_downloads and link.download_count >= link.max_downloads:
             db.delete(link)
             db.commit()
@@ -1342,6 +1359,7 @@ def list_files():
                     "rejected": l.rejected,
                     "max_downloads": l.max_downloads,
                     "download_count": l.download_count or 0,
+                    "is_internal": bool(l.is_internal),
                 }
                 for l in db.query(ShareLink)
                 .filter_by(username=username)
@@ -1408,7 +1426,7 @@ def list_files():
                     "public_expires_in": format_remaining(link_exp - now)
                     if link_exp
                     else "",
-                    "link": f"{PUBLIC_BASE_URL}/public/{token}" if token and not rejected else "",
+                    "link": f"{get_share_base_url(is_internal=link_info.get('is_internal', False))}/public/{token}" if token and not rejected else "",
                     "approved": approved,
                     "rejected": rejected,
                     "manager_name": mgr_name,
@@ -1416,6 +1434,7 @@ def list_files():
                     "message_count": msg_counts.get(filename, 0),
                     "max_downloads": max_dl,
                     "remaining_downloads": remaining_dl,
+                    "is_internal": link_info.get("is_internal", False),
                 }
             )
         files.sort(key=lambda f: f["added_ts"], reverse=True)
@@ -1442,6 +1461,7 @@ def list_files():
                 "rejected": l.rejected,
                 "max_downloads": l.max_downloads,
                 "download_count": l.download_count or 0,
+                "is_internal": bool(l.is_internal),
             }
             for l in db.query(ShareLink)
             .filter(ShareLink.rejected == False)
@@ -1521,7 +1541,7 @@ def list_files():
                     "public_expires_in": format_remaining(link_exp - now)
                     if link_exp
                     else "",
-                    "link": f"{PUBLIC_BASE_URL}/public/{token}" if token and not rejected else "",
+                    "link": f"{get_share_base_url(is_internal=link_info.get('is_internal', False))}/public/{token}" if token and not rejected else "",
                     "approved": approved,
                     "rejected": rejected,
                     "manager_name": mgr_name,
@@ -1529,6 +1549,7 @@ def list_files():
                     "message_count": msg_counts.get((user, filename), 0),
                     "max_downloads": max_dl,
                     "remaining_downloads": remaining_dl,
+                    "is_internal": link_info.get("is_internal", False),
                 }
             )
     files.sort(key=lambda f: f["added_ts"], reverse=True)
@@ -1876,6 +1897,7 @@ def share_file():
     purpose = request.form.get("purpose", "").strip()
     max_downloads = request.form.get("max_downloads")
     share_password = request.form.get("share_password", "").strip()
+    internal_only = request.form.get("internal_only", "0") == "1"
     if not purpose:
         return jsonify(success=False, error="Kullanım amacı gerekli")
     token = find_share_token(username, filename)
@@ -1898,8 +1920,8 @@ def share_file():
             if not expires_at or expires_at > file_exp:
                 expires_at = file_exp
         approver_user, approver_email, _ = get_manager_info(username)
-        auto_approve = is_admin(username) or not approver_user
-        if not approver_user:
+        auto_approve = internal_only or is_admin(username) or not approver_user
+        if not internal_only and not approver_user:
             approver_user = next(iter(ADMIN_USERS), None)
             approver_email = get_user_email(approver_user) if approver_user else ""
         approve_token = None
@@ -1920,6 +1942,7 @@ def share_file():
             purpose=purpose,
             max_downloads=max_dl,
             share_password_hash=share_password_hash,
+            is_internal=internal_only,
         )
         log_activity(
             username,
@@ -1932,7 +1955,7 @@ def share_file():
                 username,
                 f"'{filename}' paylaşımı onaylandı",
             )
-        else:
+        elif not internal_only:
             send_approval_email(
                 username,
                 filename,
@@ -1947,7 +1970,7 @@ def share_file():
                     approver_user,
                     f"'{filename}' dosyası için onay bekleyen paylaşım",
                 )
-    return jsonify(success=True, link=f"{PUBLIC_BASE_URL}/public/{token}")
+    return jsonify(success=True, link=f"{get_share_base_url(is_internal=internal_only)}/public/{token}")
 
 
 @app.route("/share/delete", methods=["POST"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -19,6 +19,7 @@ class ShareLink(Base):
     max_downloads = Column(Integer, nullable=True)
     download_count = Column(Integer, default=0)
     share_password_hash = Column(String, nullable=True)
+    is_internal = Column(Boolean, default=False)
 
 
 class DownloadLog(Base):

--- a/backend/templates/app.html
+++ b/backend/templates/app.html
@@ -382,6 +382,12 @@
         <input type="number" id="share-max-downloads" class="form-control" min="1" placeholder="Opsiyonel">
         <label class="form-label mt-3">Paylaşım Şifresi</label>
         <input type="password" id="share-password" class="form-control" placeholder="Opsiyonel">
+        <div class="form-check mt-3">
+          <input class="form-check-input" type="checkbox" id="share-internal-only">
+          <label class="form-check-label" for="share-internal-only">
+            Kurum içi (onaysız, sadece send.baylan.local üzerinden erişim)
+          </label>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="share-confirm">Paylaş</button>
@@ -561,6 +567,7 @@ const editBtn = document.getElementById('edit-selected');
 const shareBtn = document.getElementById('share-selected');
 const addToTeamBtn = document.getElementById('add-to-team');
 const publicShareBtn = document.getElementById('public-share');
+const shareInternalOnlyCheckbox = document.getElementById('share-internal-only');
 const searchInput = document.getElementById('file-search');
 searchInput.value = '';
 searchInput.setAttribute('autocomplete', 'off');
@@ -1630,7 +1637,19 @@ publicShareBtn.addEventListener('click', () => {
         }
         document.getElementById('share-max-downloads').value = '';
         document.getElementById('share-password').value = '';
+        shareInternalOnlyCheckbox.checked = false;
         modal.show();
+    }
+});
+
+shareInternalOnlyCheckbox.addEventListener('change', () => {
+    const msgAlert = document.getElementById('manager-approval-alert');
+    if (shareInternalOnlyCheckbox.checked) {
+        msgAlert.classList.add('d-none');
+        return;
+    }
+    if (managerName) {
+        msgAlert.classList.remove('d-none');
     }
 });
 
@@ -1644,6 +1663,7 @@ document.getElementById('share-confirm').addEventListener('click', async () => {
     }
     const maxDownloads = document.getElementById('share-max-downloads').value;
     const sharePassword = document.getElementById('share-password').value;
+    const internalOnly = shareInternalOnlyCheckbox.checked;
     const formData = new FormData();
     formData.append('username', username);
     formData.append('filename', shareFileName);
@@ -1654,6 +1674,9 @@ document.getElementById('share-confirm').addEventListener('click', async () => {
     }
     if (sharePassword) {
         formData.append('share_password', sharePassword);
+    }
+    if (internalOnly) {
+        formData.append('internal_only', '1');
     }
     await fetch('/share', { method: 'POST', body: formData });
     bootstrap.Modal.getInstance(document.getElementById('shareLinkModal')).hide();


### PR DESCRIPTION
### Motivation
- Provide a simple "Kurum içi" option in the share UI that creates an internal-only public link which does not require manager approval and is only accessible from the internal host. 
- Prevent privilege escalation where an internally-generated link could be reused via the public domain by forcing host-based access checks.

### Description
- Added a `Kurum içi` checkbox to the Share modal (`backend/templates/app.html`) and send `internal_only=1` with `/share` when checked. 
- Extended the `ShareLink` model with a boolean `is_internal` flag and added a DB migration/backfill in `backend/database.py`. 
- Implemented backend behavior in `backend/main.py` so internal-only shares are marked `is_internal`, auto-approved (skip approval email), and responses use the internal base URL when appropriate via `get_share_base_url`. 
- Enforced host restriction in `validate_public_link` so an `is_internal` link is rejected unless the request host matches the configured internal host (`INTERNAL_BASE_URL`).

### Testing
- Compiled the modified modules with `python -m py_compile backend/main.py backend/database.py backend/models.py` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e97e01a4832b8e52f99d0469314b)