### PR TITLE
Fix protected public download not starting

### DIFF
--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -98,10 +98,13 @@ function triggerDownloadFromBlob(blob, filename) {
     const a = document.createElement('a');
     a.href = url;
     a.download = filename || '';
+    a.style.display = 'none';
     document.body.appendChild(a);
     a.click();
-    a.remove();
-    window.URL.revokeObjectURL(url);
+    setTimeout(() => {
+        a.remove();
+        window.URL.revokeObjectURL(url);
+    }, 1000);
 }
 
 async function requestProtectedDownload(password) {


### PR DESCRIPTION
### Motivation
- Users reported that password-protected public downloads accepted the correct password but the browser did not start the download because the temporary blob URL and anchor were removed immediately, so the change delays cleanup to avoid browser timing issues.

### Description
- In `backend/templates/public.html` the download helper `triggerDownloadFromBlob` now sets `a.style.display = 'none'` and uses `setTimeout` to remove the anchor and call `URL.revokeObjectURL` after 1s so the browser has time to start the download.

### Testing
- Ran `python -m py_compile backend/main.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb682bfd9c832ba19f68d54f64d74c)