### PR TITLE
Speed up protected download start on public page

### DIFF
--- a/backend/templates/public.html
+++ b/backend/templates/public.html
@@ -101,10 +101,10 @@ function triggerDownloadFromBlob(blob, filename) {
     a.style.display = 'none';
     document.body.appendChild(a);
     a.click();
-    setTimeout(() => {
+    requestAnimationFrame(() => {
         a.remove();
         window.URL.revokeObjectURL(url);
-    }, 1000);
+    });
 }
 
 async function requestProtectedDownload(password) {


### PR DESCRIPTION
### Motivation
- Remove the artificial 1 second client-side delay so a password-protected download begins immediately after correct password entry.

### Description
- Replace `setTimeout(..., 1000)` with `requestAnimationFrame(...)` in `triggerDownloadFromBlob` inside `backend/templates/public.html` so cleanup runs on the next frame and the browser can start the download without the fixed delay.

### Testing
- No automated tests were executed for this small frontend timing adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb74208da8832ba79ba72fabd91841)